### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Re-run `alcove setup` anytime to change settings. It remembers your previous cho
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/epicsagas-alcove).
+
 ## How it works
 
 ```mermaid


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/epicsagas-alcove).