### PR TITLE
feat(embed): replace fastembed with candle-transformers for cross-platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check
-        run: cargo check --all-targets --features full-macos
+        run: cargo check --all-targets --features full-cross
       - name: Clippy
-        run: cargo clippy --features full-macos -- -D warnings
+        run: cargo clippy --features full-cross -- -D warnings
       - name: Format
         run: cargo fmt --all -- --check
 
@@ -48,8 +48,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Install openssl dev libraries
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get install -y libssl-dev:arm64
+        continue-on-error: true
       - name: Check (${{ matrix.target }})
         run: cargo check --target ${{ matrix.target }} --features full-cross
+        env:
+          OPENSSL_NO_VENDOR: 1
+          OPENSSL_DIR: /usr
 
   cross-check-windows:
     name: Cross-Platform Check (x86_64-pc-windows-msvc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,21 +23,56 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check
-        run: cargo check --all-targets --features full
+        run: cargo check --all-targets --features full-macos
       - name: Clippy
-        run: cargo clippy --features full -- -D warnings
+        run: cargo clippy --features full-macos -- -D warnings
       - name: Format
         run: cargo fmt --all -- --check
 
+  cross-check:
+    name: Cross-Platform Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Check (${{ matrix.target }})
+        run: cargo check --target ${{ matrix.target }} --features full-cross
+
+  macos-intel-check:
+    name: macOS x86_64 Check
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (x86_64-apple-darwin)
+        run: cargo check --target x86_64-apple-darwin --features full-cross
+
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Test
-        run: cargo test
+        run: cargo test --features full-macos -- --test-threads=1
 
   audit:
     name: Security Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,14 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
 
-  cross-check:
-    name: Cross-Platform Check
+  cross-check-linux:
+    name: Cross-Platform Check (${{ matrix.target }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
-          - x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -51,6 +50,18 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Check (${{ matrix.target }})
         run: cargo check --target ${{ matrix.target }} --features full-cross
+
+  cross-check-windows:
+    name: Cross-Platform Check (x86_64-pc-windows-msvc)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (x86_64-pc-windows-msvc)
+        run: cargo check --target x86_64-pc-windows-msvc --features full-cross
 
   macos-intel-check:
     name: macOS x86_64 Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-      - name: Install openssl dev libraries
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get install -y libssl-dev:arm64
-        continue-on-error: true
       - name: Check (${{ matrix.target }})
         run: cargo check --target ${{ matrix.target }} --features full-cross
-        env:
-          OPENSSL_NO_VENDOR: 1
-          OPENSSL_DIR: /usr
 
   cross-check-windows:
     name: Cross-Platform Check (x86_64-pc-windows-msvc)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,20 +64,23 @@ dependencies = [
 
 [[package]]
 name = "alcove"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "axum",
  "calamine",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
  "chrono",
  "clap",
- "console",
+ "console 0.16.3",
  "dialoguer",
  "dirs",
- "fastembed",
+ "hf-hub",
  "hnsw_rs",
  "indexmap",
- "indicatif",
+ "indicatif 0.18.4",
  "libc",
  "pdf-extract",
  "quick-xml",
@@ -93,30 +96,13 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenizers 0.21.4",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tower-http",
- "ureq",
+ "ureq 3.3.0",
  "walkdir",
  "zip 8.6.0",
-]
-
-[[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
 ]
 
 [[package]]
@@ -208,44 +194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -279,49 +233,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "axum"
@@ -394,12 +305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,10 +314,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -433,15 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "bitstream-io"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
 ]
 
 [[package]]
@@ -508,12 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,18 +429,26 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -573,6 +480,65 @@ dependencies = [
  "quick-xml",
  "serde",
  "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "tokenizers 0.22.2",
+ "yoke",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+dependencies = [
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
 ]
 
 [[package]]
@@ -729,12 +695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +727,19 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -788,35 +761,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1052,16 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,7 +1042,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console",
+ "console 0.16.3",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
@@ -1171,19 +1105,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "ecb"
@@ -1251,26 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1223,9 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "euclid"
@@ -1310,21 +1234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
 ]
 
 [[package]]
@@ -1340,6 +1249,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,42 +1272,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
-name = "fastembed"
-version = "5.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0112bd54a5d1903b19c85609c282949523bb8bb39f1614d4db0017e0ef3b0ff"
-dependencies = [
- "anyhow",
- "hf-hub",
- "image",
- "ndarray",
- "ort",
- "safetensors",
- "serde",
- "serde_json",
- "tokenizers",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1404,6 +1292,18 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
 ]
 
 [[package]]
@@ -1459,12 +1359,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1519,6 +1435,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1536,6 +1453,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
 ]
 
 [[package]]
@@ -1585,16 +1621,6 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -1652,8 +1678,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -1710,23 +1740,26 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf-hub"
-version = "0.5.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
+ "futures",
  "http",
- "indicatif",
+ "indicatif 0.17.11",
  "libc",
  "log",
  "native-tls",
+ "num_cpus",
  "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
- "windows-sys 0.61.2",
+ "tokio",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1737,12 +1770,6 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
 ]
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hnsw_rs"
@@ -2063,46 +2090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,11 +2103,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -2144,17 +2144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2261,12 +2250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,14 +2268,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2309,6 +2288,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2326,12 +2306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,15 +2319,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
 
 [[package]]
 name = "lopdf"
@@ -2400,12 +2365,6 @@ checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
-
-[[package]]
-name = "lzma-rust2"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
@@ -2445,26 +2404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2571,16 +2511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,27 +2534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,15 +2543,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2676,12 +2576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "normpath"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,21 +2585,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2716,43 +2601,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2764,6 +2619,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -2864,30 +2725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ort"
-version = "2.0.0-rc.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
-dependencies = [
- "ndarray",
- "ort-sys",
- "smallvec",
- "tracing",
- "ureq",
-]
-
-[[package]]
-name = "ort-sys"
-version = "2.0.0-rc.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
-dependencies = [
- "hmac-sha256",
- "lzma-rust2 0.15.7",
- "ureq",
-]
-
-[[package]]
 name = "ownedbytes"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,12 +2763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,15 +2790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,19 +2806,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.1",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "pom"
@@ -3075,44 +2884,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.18"
+name = "pulp"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
 dependencies = [
  "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
 ]
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "quick-xml"
@@ -3192,66 +2984,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
+name = "raw-cpuid"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.4",
- "rand_chacha",
- "simd_helpers",
- "thiserror 2.0.18",
- "v_frame",
- "wasm-bindgen",
+ "bitflags 2.11.1",
 ]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3283,6 +3038,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -3375,12 +3136,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3628,6 +3383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3440,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3789,15 +3559,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
 
 [[package]]
 name = "siphasher"
@@ -4192,20 +3953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4008,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif 0.17.11",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokenizers"
@@ -4488,7 +4269,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4654,26 +4447,39 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
- "cookie_store",
- "der",
  "flate2",
  "log",
  "native-tls",
- "percent-encoding",
+ "once_cell",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4733,17 +4539,6 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
  "wasm-bindgen",
 ]
 
@@ -4925,12 +4720,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "rustls-pki-types",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5084,6 +4879,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5115,11 +4919,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5135,6 +4956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,6 +4972,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5159,10 +4992,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5177,6 +5022,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5187,6 +5038,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5201,6 +5058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,6 +5074,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5326,12 +5195,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -5465,7 +5328,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hmac",
  "indexmap",
- "lzma-rust2 0.16.2",
+ "lzma-rust2",
  "memchr",
  "pbkdf2",
  "ppmd-rust",
@@ -5527,28 +5390,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,26 +763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,21 +1305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,28 +1324,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1401,12 +1350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,12 +1359,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1435,13 +1372,9 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1654,25 +1587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,19 +1659,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
- "futures",
  "http",
  "indicatif 0.17.11",
  "libc",
  "log",
- "native-tls",
- "num_cpus",
  "rand 0.9.4",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
 ]
@@ -1866,7 +1775,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1875,38 +1783,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1915,23 +1791,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
- "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2154,12 +2020,6 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2517,23 +2377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,49 +2507,6 @@ checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3095,49 +2895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,15 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,29 +3100,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -3683,9 +3408,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -3719,27 +3441,6 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4082,7 +3783,6 @@ version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
- "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -4100,39 +3800,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -4239,14 +3906,10 @@ checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
- "futures-util",
  "http",
- "http-body",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]
@@ -4303,12 +3966,6 @@ dependencies = [
  "serde",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -4454,7 +4111,6 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
@@ -4565,15 +4221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,16 +4255,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4675,19 +4312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,16 +4321,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4829,17 +4443,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror 2.0.18",
- "tokenizers 0.21.4",
+ "tokenizers",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tower-http",
@@ -501,7 +501,7 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror 2.0.18",
- "tokenizers 0.22.2",
+ "tokenizers",
  "yoke",
  "zip 7.2.0",
 ]
@@ -3712,40 +3712,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
-dependencies = [
- "ahash",
- "aho-corasick",
- "compact_str",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "indicatif 0.17.11",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.4",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.18",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
-name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
@@ -3757,6 +3723,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
+ "indicatif 0.18.4",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ candle-transformers = { version = "0.10", optional = true }
 candle-nn = { version = "0.10", optional = true }
 candle-core = { version = "0.10", optional = true }
 hf-hub = { version = "0.4", default-features = false, features = ["ureq"], optional = true }
-tokenizers = { version = "0.21", optional = true }
+tokenizers = { version = "0.22", optional = true }
 
 # Storage & indexing
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
@@ -86,7 +86,7 @@ alcove-server = ["axum", "tokio", "tower-http"]
 full-macos = ["core", "embed-candle", "vector", "pdf", "office", "alcove-server"]
 full-cross = ["core", "embed-candle", "vector", "office", "alcove-server"]
 # Backward compat: full = full-macos on existing macOS ARM builds
-full = ["full-macos"]
+full = ["full-cross"]
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 candle-transformers = { version = "0.10", optional = true }
 candle-nn = { version = "0.10", optional = true }
 candle-core = { version = "0.10", optional = true }
-hf-hub = { version = "0.4", optional = true }
+hf-hub = { version = "0.4", default-features = false, features = ["ureq"], optional = true }
 tokenizers = { version = "0.21", optional = true }
 
 # Storage & indexing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,19 @@ sys-locale = "0.3.2"
 tantivy = "0.26"
 chrono = { version = "0.4", features = ["clock"] }
 
-# alcove-full feature dependencies (lazy embedding + vector search)
-fastembed = { version = "5", optional = true }
-rusqlite = { version = "0.39", optional = true }
-pdf-extract = { version = "0.10", optional = true }
+# Embedding backends (mutually exclusive in practice)
+candle-transformers = { version = "0.10", optional = true }
+candle-nn = { version = "0.10", optional = true }
+candle-core = { version = "0.10", optional = true }
+hf-hub = { version = "0.4", optional = true }
+tokenizers = { version = "0.21", optional = true }
+
+# Storage & indexing
+rusqlite = { version = "0.39", features = ["bundled"], optional = true }
+hnsw_rs = { version = "0.3", optional = true }
+
+# Document parsers
+pdf-extract = { version = "0.10", optional = true }  # Unix-only
 zip = { version = "8.5", optional = true }
 quick-xml = { version = "0.39", optional = true }
 calamine = { version = "0.34", optional = true }
@@ -59,19 +68,25 @@ calamine = { version = "0.34", optional = true }
 # Lightweight sync HTTP client for MCP proxy mode
 ureq = "3"
 
-# HTTP server dependencies (alcove-server feature)
+# HTTP server dependencies
 axum = { version = "0.8", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
 
-# HNSW vector indexing (alcove-full feature)
-hnsw_rs = { version = "0.3", optional = true }
-
 [features]
-default = ["full"]
-alcove-full = ["fastembed", "rusqlite", "hnsw_rs", "pdf-extract", "zip", "quick-xml", "calamine"]
+default = ["core"]
+core = ["rusqlite", "alcove-server"]
+embed-candle = ["candle-transformers", "candle-nn", "candle-core", "hf-hub", "tokenizers"]
+vector = ["hnsw_rs"]
+pdf = ["pdf-extract"]
+office = ["zip", "quick-xml", "calamine"]
 alcove-server = ["axum", "tokio", "tower-http"]
-full = ["alcove-full", "alcove-server"]
+
+# Preset feature groups
+full-macos = ["core", "embed-candle", "vector", "pdf", "office", "alcove-server"]
+full-cross = ["core", "embed-candle", "vector", "office", "alcove-server"]
+# Backward compat: full = full-macos on existing macOS ARM builds
+full = ["full-macos"]
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,22 +7,21 @@ cargo-dist-version = "0.31.0"
 ci = "github"
 targets = [
   "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
 ]
-# ort-sys/ONNX Runtime prebuilt binary constraints (v2.0.0-rc.12):
-#   aarch64-apple-darwin: ✅ supported (cdn.pyke.io)
-#   x86_64-apple-darwin: ❌ no prebuilt available
-#   x86_64-unknown-linux-gnu: ❌ requires glibc 2.38+ (ubuntu-22.04 runner has 2.35)
-#   Windows: ❌ DirectML/ring failures
-installers = ["homebrew"]
+installers = ["homebrew", "shell", "powershell"]
 tap = "epicsagas/homebrew-tap"
 create-release = true
-features = ["full"]
+features = ["full-macos"]
+features-aarch64-unknown-linux-gnu = ["full-cross"]
+features-x86_64-unknown-linux-gnu = ["full-cross"]
+features-x86_64-pc-windows-msvc = ["full-cross"]
+features-x86_64-apple-darwin = ["full-cross"]
 install-path = "CARGO_HOME"
 install-updater = false
 publish-jobs = ["homebrew", "./publish-crates"]
 allow-dirty = ["ci"]
 macos-sign = false
-
-# NOTE: musl targets omitted — fastembed/ONNX Runtime ships glibc-linked prebuilt
-# binaries and cannot compile on musl. If static-linked Linux builds are needed,
-# use a glibc container with a minimal glibc version (e.g. manylinux).

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,6 +16,7 @@ installers = ["homebrew", "shell", "powershell"]
 tap = "epicsagas/homebrew-tap"
 create-release = true
 features = ["full-macos"]
+features-aarch64-apple-darwin = ["full-macos"]
 features-aarch64-unknown-linux-gnu = ["full-cross"]
 features-x86_64-unknown-linux-gnu = ["full-cross"]
 features-x86_64-pc-windows-msvc = ["full-cross"]

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: alcove
-description: >
-  Grounds the agent in authoritative internal project documentation stored in a private Alcove docs repository.
-  Covers project design, architecture, requirements, progress tracking, coding conventions,
-  technical debt, secrets mapping, and environment configuration.
-  Also initializes, organizes, audits, validates, lints, and promotes project documentation.
-  Activates whenever the agent needs authoritative project information — regardless of input language.
+description: "Trigger: any need for authoritative project docs — design, architecture, requirements, conventions, tech debt, secrets, env config. Also inits, audits, lints, and promotes docs."
 ---
 
 # Alcove

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -260,7 +260,7 @@ fn get_docs_root() -> Result<PathBuf> {
 }
 
 /// Expand tilde in cache_dir and create an EmbeddingService from config.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn create_embedding_service(
     emb_cfg: &crate::config::EmbeddingConfig,
 ) -> crate::embedding::EmbeddingService {
@@ -334,8 +334,8 @@ fn run_precision_benchmark(
         });
     }
 
-    // Hybrid search (only if alcove-full feature is enabled)
-    #[cfg(feature = "alcove-full")]
+    // Hybrid search (only if embed-candle feature is enabled)
+    #[cfg(feature = "embed-candle")]
     let hybrid_results = {
         let mut results: Vec<PerQueryPrecision> = Vec::new();
         let cfg = crate::config::load_config();
@@ -372,7 +372,7 @@ fn run_precision_benchmark(
         }
     };
 
-    #[cfg(not(feature = "alcove-full"))]
+    #[cfg(not(feature = "embed-candle"))]
     let hybrid_results: Option<Vec<PerQueryPrecision>> = None;
 
     Ok(PrecisionResults {
@@ -455,8 +455,8 @@ fn run_latency_benchmark(
         });
     }
 
-    // Hybrid latency (only if alcove-full feature is enabled)
-    #[cfg(feature = "alcove-full")]
+    // Hybrid latency (only if embed-candle feature is enabled)
+    #[cfg(feature = "embed-candle")]
     let hybrid_entries = {
         let mut entries: Vec<LatencyEntry> = Vec::new();
         let cfg = crate::config::load_config();
@@ -492,7 +492,7 @@ fn run_latency_benchmark(
         }
     };
 
-    #[cfg(not(feature = "alcove-full"))]
+    #[cfg(not(feature = "embed-candle"))]
     let hybrid_entries: Option<Vec<LatencyEntry>> = None;
 
     Ok(LatencyResults {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub use crate::commands::{
     cmd_uninstall, cmd_validate,
 };
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub use crate::commands::cmd_model;
 
 #[cfg(unix)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -722,10 +722,10 @@ pub fn cmd_uninstall() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Model subcommand (alcove-full feature)
+// Model subcommand (embed-candle feature)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub fn cmd_model(subcmd: crate::ModelCommands) -> Result<()> {
     use crate::ModelCommands;
 
@@ -738,7 +738,7 @@ pub fn cmd_model(subcmd: crate::ModelCommands) -> Result<()> {
     }
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn cmd_model_list() -> Result<()> {
     use crate::embedding::EmbeddingModelChoice;
 
@@ -766,14 +766,9 @@ fn cmd_model_list() -> Result<()> {
             ""
         };
         let desc = match model {
-            EmbeddingModelChoice::SnowflakeArcticEmbedXS => "Mobile/low-spec, fastest",
-            EmbeddingModelChoice::SnowflakeArcticEmbedXSQ => "Quantized XS, smallest",
-            EmbeddingModelChoice::MultilingualE5Small => "Default, balanced (100+ langs)",
-            EmbeddingModelChoice::SnowflakeArcticEmbedS => "Quality/size balance",
-            EmbeddingModelChoice::SnowflakeArcticEmbedSQ => "Quantized S",
+            EmbeddingModelChoice::AllMiniLML6V2 => "Default, fast & lightweight (80MB)",
+            EmbeddingModelChoice::MultilingualE5Small => "Multilingual balanced (100+ langs)",
             EmbeddingModelChoice::MultilingualE5Base => "Large scale docs",
-            EmbeddingModelChoice::SnowflakeArcticEmbedM => "Medium, 768d",
-            EmbeddingModelChoice::SnowflakeArcticEmbedMQ => "Quantized M",
             EmbeddingModelChoice::MultilingualE5Large => "Best quality, heavy",
             EmbeddingModelChoice::BGEM3 => "Dense+Sparse+ColBERT",
         };
@@ -794,9 +789,9 @@ fn cmd_model_list() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn cmd_model_download() -> Result<()> {
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     {
         use crate::embedding::EmbeddingService;
 
@@ -846,19 +841,19 @@ fn cmd_model_download() -> Result<()> {
         println!("Cache location: {}", cfg.cache_dir);
     }
 
-    #[cfg(not(feature = "alcove-full"))]
+    #[cfg(not(feature = "embed-candle"))]
     {
         println!(
-            "{} The 'alcove-full' feature is required for embedding support.",
+            "{} The 'embed-candle' feature is required for embedding support.",
             style("✗").red()
         );
-        println!("Install with: cargo install alcove --features alcove-full");
+        println!("Install with: cargo install alcove --features embed-candle");
     }
 
     Ok(())
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn cmd_model_remove() -> Result<()> {
     let cfg = load_config().embedding_config_with_defaults();
     let cache_dir = std::path::PathBuf::from(
@@ -901,7 +896,7 @@ fn cmd_model_remove() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn cmd_model_set(model_name: &str) -> Result<()> {
     use crate::embedding::EmbeddingModelChoice;
 
@@ -972,7 +967,7 @@ fn cmd_model_set(model_name: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn cmd_model_status() -> Result<()> {
     let cfg = load_config();
     let emb_cfg = cfg.embedding_config_with_defaults();
@@ -1209,9 +1204,7 @@ pub fn cmd_reap() -> Result<()> {
             continue;
         }
 
-        unsafe {
-            libc::kill(pid as i32, libc::SIGTERM);
-        }
+        crate::platform::send_terminate(pid);
         reaped += 1;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,30 +217,30 @@ impl Default for ServerConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Embedding config (alcove-full feature)
+// Embedding config (embed-candle feature)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn default_embedding_model() -> String {
     "MultilingualE5Small".into()
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn default_embedding_auto_download() -> bool {
     true
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn default_embedding_enabled() -> bool {
     true
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn default_embedding_cache_dir() -> String {
     alcove_home().join("models").to_string_lossy().to_string()
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EmbeddingConfig {
     /// Model name (e.g., "MultilingualE5Small", "SnowflakeArcticEmbedXS")
@@ -260,12 +260,12 @@ pub struct EmbeddingConfig {
     pub query_cache_size: usize,
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn default_query_cache_size() -> usize {
     64
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 impl Default for EmbeddingConfig {
     fn default() -> Self {
         Self {
@@ -278,7 +278,7 @@ impl Default for EmbeddingConfig {
     }
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 impl EmbeddingConfig {
     /// Get the model name as a string
     #[allow(dead_code)]
@@ -362,8 +362,8 @@ pub struct DocConfig {
     /// Example: `extra_extensions = ["yaml", "json"]`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_extensions: Option<Vec<String>>,
-    /// Embedding configuration for hybrid search (alcove-full feature)
-    #[cfg(feature = "alcove-full")]
+    /// Embedding configuration for hybrid search (embed-candle feature)
+    #[cfg(feature = "embed-candle")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<EmbeddingConfig>,
     /// HTTP server configuration (`alcove serve`).
@@ -390,7 +390,7 @@ impl DocConfig {
                 .extra_extensions
                 .clone()
                 .or_else(|| base.extra_extensions.clone()),
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding: self.embedding.clone().or_else(|| base.embedding.clone()),
             server: self.server.clone().or_else(|| base.server.clone()),
             memory: self.memory.clone().or_else(|| base.memory.clone()),
@@ -487,14 +487,14 @@ impl DocConfig {
     }
 
     /// Get embedding configuration as TOML struct
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     #[allow(dead_code)]
     pub fn embedding_config(&self) -> &Option<EmbeddingConfig> {
         &self.embedding
     }
 
     /// Get embedding configuration with defaults applied
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     pub fn embedding_config_with_defaults(&self) -> EmbeddingConfig {
         self.embedding.clone().unwrap_or_default()
     }
@@ -560,7 +560,7 @@ pub fn load_config() -> &'static DocConfig {
             diagram: None,
             index: None,
             extra_extensions: None,
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding: None,
             server: None,
             memory: None,
@@ -572,7 +572,7 @@ pub fn load_config() -> &'static DocConfig {
 ///
 /// Reads `VAULT_PATH/.alcove/vault.toml` for an `[embedding]` section.
 /// If missing or partially specified, fields fall back to the global config.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub fn vault_embedding_config(vault_path: &Path) -> EmbeddingConfig {
     // Check two locations in priority order:
     //   1. VAULT_PATH/.alcove/vault.toml  (alcove-native, takes precedence)

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -1,45 +1,44 @@
-//! Embedding service for hybrid search (alcove-full feature)
+//! Embedding service for hybrid search (embed-candle feature)
 //!
-//! Provides lazy model download, ONNX inference, and vector index management.
-//! Graceful degradation ensures BM25-only search works even when models aren't ready.
+//! Provides lazy model download via HuggingFace Hub, candle-transformers BERT
+//! inference, and LRU query caching. Graceful degradation ensures BM25-only
+//! search works even when models aren't ready.
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 use std::path::PathBuf;
-
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 use std::sync::{Arc, Condvar, Mutex};
-
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "alcove-full")]
-use anyhow::Result;
-#[cfg(feature = "alcove-full")]
-use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
+#[cfg(feature = "embed-candle")]
+use anyhow::{Context, Result};
+#[cfg(feature = "embed-candle")]
+use candle_core::Tensor;
+#[cfg(feature = "embed-candle")]
+use candle_nn::VarBuilder;
+#[cfg(feature = "embed-candle")]
+use candle_transformers::models::bert::{BertModel, Config, DTYPE};
+#[cfg(feature = "embed-candle")]
+use hf_hub::api::sync::Api;
+#[cfg(feature = "embed-candle")]
+use hf_hub::{Repo, RepoType};
 
 /// Model state for graceful degradation
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum ModelState {
-    /// Model not downloaded yet
     #[default]
     NotDownloaded,
-    /// Background download in progress (percentage)
     Downloading { progress_pct: u8 },
-    /// Model cached on disk, ONNX session not yet loaded
     Cached,
-    /// ONNX session loaded, ready for embedding
     Ready,
-    /// Session was loaded but unloaded after idle timeout; model still on disk.
-    /// Behaves like `Cached` — reloads on next `ensure_model()` call.
     Unloaded,
-    /// Embedding is intentionally disabled in configuration (not an error)
     Disabled,
-    /// Download or load failed
     Failed(String),
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 impl std::fmt::Display for ModelState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -54,53 +53,24 @@ impl std::fmt::Display for ModelState {
     }
 }
 
-/// Supported embedding models (Korean + multilingual)
-#[cfg_attr(not(feature = "alcove-full"), allow(dead_code))]
+/// Supported embedding models — all resolve to BERT-family architectures
+/// loadable via candle-transformers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EmbeddingModelChoice {
-    #[default]
     MultilingualE5Small,
+    #[default]
+    AllMiniLML6V2,
     MultilingualE5Base,
     MultilingualE5Large,
-    SnowflakeArcticEmbedXS,
-    SnowflakeArcticEmbedXSQ,
-    SnowflakeArcticEmbedS,
-    SnowflakeArcticEmbedSQ,
-    SnowflakeArcticEmbedM,
-    SnowflakeArcticEmbedMQ,
     BGEM3,
 }
 
-#[cfg_attr(not(feature = "alcove-full"), allow(dead_code))]
 impl EmbeddingModelChoice {
-    /// Get the fastembed model enum variant
-    #[cfg(feature = "alcove-full")]
-    pub fn as_fastembed_model(self) -> EmbeddingModel {
-        match self {
-            Self::MultilingualE5Small => EmbeddingModel::MultilingualE5Small,
-            Self::MultilingualE5Base => EmbeddingModel::MultilingualE5Base,
-            Self::MultilingualE5Large => EmbeddingModel::MultilingualE5Large,
-            Self::SnowflakeArcticEmbedXS => EmbeddingModel::SnowflakeArcticEmbedXS,
-            Self::SnowflakeArcticEmbedXSQ => EmbeddingModel::SnowflakeArcticEmbedXSQ,
-            Self::SnowflakeArcticEmbedS => EmbeddingModel::SnowflakeArcticEmbedS,
-            Self::SnowflakeArcticEmbedSQ => EmbeddingModel::SnowflakeArcticEmbedSQ,
-            Self::SnowflakeArcticEmbedM => EmbeddingModel::SnowflakeArcticEmbedM,
-            Self::SnowflakeArcticEmbedMQ => EmbeddingModel::SnowflakeArcticEmbedMQ,
-            Self::BGEM3 => EmbeddingModel::BGEM3,
-        }
-    }
-
     /// Get embedding dimension for this model
     pub fn dimension(&self) -> usize {
         match self {
-            Self::MultilingualE5Small
-            | Self::SnowflakeArcticEmbedXS
-            | Self::SnowflakeArcticEmbedXSQ
-            | Self::SnowflakeArcticEmbedS
-            | Self::SnowflakeArcticEmbedSQ => 384,
-            Self::MultilingualE5Base
-            | Self::SnowflakeArcticEmbedM
-            | Self::SnowflakeArcticEmbedMQ => 768,
+            Self::AllMiniLML6V2 | Self::MultilingualE5Small => 384,
+            Self::MultilingualE5Base => 768,
             Self::MultilingualE5Large | Self::BGEM3 => 1024,
         }
     }
@@ -108,109 +78,64 @@ impl EmbeddingModelChoice {
     /// Approximate model size in MB
     pub fn size_mb(&self) -> usize {
         match self {
-            Self::SnowflakeArcticEmbedXS => 30,
-            Self::SnowflakeArcticEmbedXSQ => 15,
-            Self::SnowflakeArcticEmbedS => 130,
-            Self::SnowflakeArcticEmbedSQ => 65,
-            Self::MultilingualE5Small => 235, // O4 optimized
-            Self::SnowflakeArcticEmbedM => 400,
-            Self::SnowflakeArcticEmbedMQ => 200,
-            Self::MultilingualE5Base => 555, // O4 optimized
+            Self::AllMiniLML6V2 => 80,
+            Self::MultilingualE5Small => 470,
+            Self::MultilingualE5Base => 1100,
             Self::MultilingualE5Large => 2200,
             Self::BGEM3 => 2300,
         }
     }
 
-    /// Parse from string (for config file)
     pub fn parse(s: &str) -> Option<Self> {
         match s {
+            "AllMiniLML6V2" => Some(Self::AllMiniLML6V2),
             "MultilingualE5Small" => Some(Self::MultilingualE5Small),
             "MultilingualE5Base" => Some(Self::MultilingualE5Base),
             "MultilingualE5Large" => Some(Self::MultilingualE5Large),
-            "SnowflakeArcticEmbedXS" => Some(Self::SnowflakeArcticEmbedXS),
-            "SnowflakeArcticEmbedXSQ" => Some(Self::SnowflakeArcticEmbedXSQ),
-            "SnowflakeArcticEmbedS" => Some(Self::SnowflakeArcticEmbedS),
-            "SnowflakeArcticEmbedSQ" => Some(Self::SnowflakeArcticEmbedSQ),
-            "SnowflakeArcticEmbedM" => Some(Self::SnowflakeArcticEmbedM),
-            "SnowflakeArcticEmbedMQ" => Some(Self::SnowflakeArcticEmbedMQ),
             "BGEM3" => Some(Self::BGEM3),
             _ => None,
         }
     }
 
-    /// Convert to string (for config file)
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::AllMiniLML6V2 => "AllMiniLML6V2",
             Self::MultilingualE5Small => "MultilingualE5Small",
             Self::MultilingualE5Base => "MultilingualE5Base",
             Self::MultilingualE5Large => "MultilingualE5Large",
-            Self::SnowflakeArcticEmbedXS => "SnowflakeArcticEmbedXS",
-            Self::SnowflakeArcticEmbedXSQ => "SnowflakeArcticEmbedXSQ",
-            Self::SnowflakeArcticEmbedS => "SnowflakeArcticEmbedS",
-            Self::SnowflakeArcticEmbedSQ => "SnowflakeArcticEmbedSQ",
-            Self::SnowflakeArcticEmbedM => "SnowflakeArcticEmbedM",
-            Self::SnowflakeArcticEmbedMQ => "SnowflakeArcticEmbedMQ",
             Self::BGEM3 => "BGEM3",
         }
     }
 
-    /// List all available models
     pub fn all() -> &'static [Self] {
         &[
-            Self::SnowflakeArcticEmbedXS,
-            Self::SnowflakeArcticEmbedXSQ,
+            Self::AllMiniLML6V2,
             Self::MultilingualE5Small,
-            Self::SnowflakeArcticEmbedS,
-            Self::SnowflakeArcticEmbedSQ,
             Self::MultilingualE5Base,
-            Self::SnowflakeArcticEmbedM,
-            Self::SnowflakeArcticEmbedMQ,
             Self::MultilingualE5Large,
             Self::BGEM3,
         ]
     }
 
-    /// Get the HuggingFace model ID
     pub fn model_id(self) -> &'static str {
         match self {
+            Self::AllMiniLML6V2 => "sentence-transformers/all-MiniLM-L6-v2",
             Self::MultilingualE5Small => "intfloat/multilingual-e5-small",
             Self::MultilingualE5Base => "intfloat/multilingual-e5-base",
             Self::MultilingualE5Large => "intfloat/multilingual-e5-large",
-            Self::SnowflakeArcticEmbedXS => "Snowflake/snowflake-arctic-embed-xs",
-            Self::SnowflakeArcticEmbedXSQ => "Snowflake/snowflake-arctic-embed-xs",
-            Self::SnowflakeArcticEmbedS => "Snowflake/snowflake-arctic-embed-s",
-            Self::SnowflakeArcticEmbedSQ => "Snowflake/snowflake-arctic-embed-s",
-            Self::SnowflakeArcticEmbedM => "Snowflake/snowflake-arctic-embed-m",
-            Self::SnowflakeArcticEmbedMQ => "Snowflake/snowflake-arctic-embed-m",
             Self::BGEM3 => "BAAI/bge-m3",
         }
     }
 
-    /// Prefix to prepend to queries before embedding.
-    ///
-    /// Some models require a task-specific prefix for retrieval queries to
-    /// produce meaningful similarity scores against document embeddings.
     pub fn query_prefix(self) -> Option<&'static str> {
         match self {
-            Self::SnowflakeArcticEmbedXS
-            | Self::SnowflakeArcticEmbedXSQ
-            | Self::SnowflakeArcticEmbedS
-            | Self::SnowflakeArcticEmbedSQ
-            | Self::SnowflakeArcticEmbedM
-            | Self::SnowflakeArcticEmbedMQ => {
-                Some("Represent this sentence for searching relevant passages: ")
-            }
             Self::MultilingualE5Small | Self::MultilingualE5Base | Self::MultilingualE5Large => {
                 Some("query: ")
             }
-            Self::BGEM3 => None,
+            Self::AllMiniLML6V2 | Self::BGEM3 => None,
         }
     }
 
-    /// Prefix to prepend to documents/passages before embedding.
-    ///
-    /// Some models distinguish between query and passage inputs at the
-    /// embedding level.  Returns `None` when no prefix is required.
     pub fn doc_prefix(self) -> Option<&'static str> {
         match self {
             Self::MultilingualE5Small | Self::MultilingualE5Base | Self::MultilingualE5Large => {
@@ -221,7 +146,6 @@ impl EmbeddingModelChoice {
     }
 }
 
-#[cfg(feature = "alcove-full")]
 impl std::fmt::Display for EmbeddingModelChoice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", (*self).as_str())
@@ -229,20 +153,15 @@ impl std::fmt::Display for EmbeddingModelChoice {
 }
 
 // ---------------------------------------------------------------------------
-// Inline LRU cache backed by IndexMap for O(1) operations
+// LRU cache backed by IndexMap
 // ---------------------------------------------------------------------------
 
-/// A simple LRU cache backed by `IndexMap` for O(1) lookup, insertion, and
-/// eviction. The front of the map (index 0) is the least-recently-used entry
-/// and the back is the most-recently-used. When `capacity` is 0 the cache is
-/// effectively disabled — every `get` returns `None` and `insert` is a no-op.
 pub struct QueryEmbedCache {
     capacity: usize,
     map: indexmap::IndexMap<String, Vec<f32>>,
 }
 
 impl QueryEmbedCache {
-    /// Create a new cache with the given capacity.
     pub fn new(capacity: usize) -> Self {
         Self {
             capacity,
@@ -250,8 +169,6 @@ impl QueryEmbedCache {
         }
     }
 
-    /// Return a reference to the cached vector for `key`, or `None`.
-    /// Accessing an entry promotes it to the most-recently-used position (back).
     pub fn get(&mut self, key: &str) -> Option<&Vec<f32>> {
         if self.capacity == 0 {
             return None;
@@ -264,62 +181,163 @@ impl QueryEmbedCache {
         }
     }
 
-    /// Insert or update an entry. Evicts the LRU entry when at capacity.
     pub fn insert(&mut self, key: String, value: Vec<f32>) {
         if self.capacity == 0 {
             return;
         }
         if let Some((k, _)) = self.map.shift_remove_entry(&key) {
-            // Re-insert at the back (MRU position) with updated value.
             self.map.insert(k, value);
         } else {
             if self.map.len() >= self.capacity {
-                self.map.shift_remove_index(0); // evict LRU (front)
+                self.map.shift_remove_index(0);
             }
             self.map.insert(key, value);
         }
     }
 }
 
-// Feature-gated implementation
+// ---------------------------------------------------------------------------
+// Candle-based embedding session (the actual inference engine)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "alcove-full")]
+/// Holds a loaded candle BERT model + tokenizer, ready for inference.
+#[cfg(feature = "embed-candle")]
+struct CandleSession {
+    model: BertModel,
+    tokenizer: tokenizers::Tokenizer,
+}
+
+#[cfg(feature = "embed-candle")]
+impl CandleSession {
+    /// Download model files from HuggingFace Hub and build a BERT session.
+    fn load(
+        model_choice: EmbeddingModelChoice,
+        _cache_dir: &std::path::Path,
+    ) -> Result<Self> {
+        let device = candle_core::Device::Cpu;
+        let model_id = model_choice.model_id();
+
+        let api = Api::new().context("Failed to create HuggingFace API client")?;
+        let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, "main".to_string());
+        let api_repo = api.repo(repo);
+
+        let config_path = api_repo
+            .get("config.json")
+            .context("Failed to download config.json")?;
+        let tokenizer_path = api_repo
+            .get("tokenizer.json")
+            .context("Failed to download tokenizer.json")?;
+        let weights_path = api_repo
+            .get("model.safetensors")
+            .context("Failed to download model.safetensors")?;
+
+        let config_str = std::fs::read_to_string(&config_path)
+            .context("Failed to read config.json")?;
+        let config: Config = serde_json::from_str(&config_str)
+            .context("Failed to parse config.json")?;
+
+        let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[weights_path], DTYPE, &device)?
+        };
+        let model = BertModel::load(vb, &config)?;
+
+        Ok(Self { model, tokenizer })
+    }
+
+    /// Embed a batch of texts, returning one Vec<f32> per text.
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let device = candle_core::Device::Cpu;
+
+        let mut tokenizer = self.tokenizer.clone();
+        tokenizer.with_padding(Some(tokenizers::PaddingParams {
+            strategy: tokenizers::PaddingStrategy::BatchLongest,
+            ..Default::default()
+        }));
+
+        let encodings = tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+
+        let token_ids = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|e| Tensor::new(e.get_ids(), &device))
+                .collect::<candle_core::Result<Vec<_>>>()?,
+            0,
+        )?;
+        let attention_mask = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|e| Tensor::new(e.get_attention_mask(), &device))
+                .collect::<candle_core::Result<Vec<_>>>()?,
+            0,
+        )?;
+        let token_type_ids = token_ids.zeros_like()?;
+
+        // Forward: [batch, seq_len, hidden_size]
+        let embeddings = self
+            .model
+            .forward(&token_ids, &token_type_ids, Some(&attention_mask))?;
+
+        // Mean pooling with attention mask
+        let mask_f = attention_mask.to_dtype(DTYPE)?.unsqueeze(2)?;
+        let sum_mask = mask_f.sum(1)?;
+        let pooled = (embeddings.broadcast_mul(&mask_f)?)
+            .sum(1)?
+            .broadcast_div(&sum_mask)?;
+
+        // L2 normalize
+        let normalized = pooled.broadcast_div(
+            &pooled.sqr()?.sum_keepdim(1)?.sqrt()?,
+        )?;
+
+        // Extract to Vec<Vec<f32>>
+        let batch_size = normalized.dims()[0];
+        (0..batch_size)
+            .map(|i| {
+                normalized
+                    .get(i)?
+                    .to_vec1::<f32>()
+                    .map_err(anyhow::Error::from)
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingService — public API (same interface, candle backend)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "embed-candle")]
 pub struct EmbeddingService {
-    /// Current model state
     state: Arc<Mutex<ModelState>>,
-    /// Condvar paired with `state` — notified when the download thread transitions
-    /// state to `Ready` or `Failed`.  Replaces the 100 ms sleep-polling loop in
-    /// `ensure_model()` so callers wake up immediately on completion.
     download_cvar: Arc<Condvar>,
-    /// Internal configuration with model choice
     internal_config: InternalEmbeddingConfig,
-    /// ONNX session (lazy loaded)
-    session: Arc<Mutex<Option<TextEmbedding>>>,
-    /// Previous model dimension (for detecting changes)
+    session: Arc<Mutex<Option<CandleSession>>>,
     #[allow(dead_code)]
     previous_dimension: Arc<Mutex<Option<usize>>>,
-    /// Timestamp of the last successful `embed()` call — used for idle unload.
     last_embed_at: Arc<Mutex<Instant>>,
-    /// Per-query embedding LRU cache to skip redundant ONNX inference.
     query_cache: Arc<Mutex<QueryEmbedCache>>,
 }
 
-/// Internal embedding configuration (not part of public API)
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 struct InternalEmbeddingConfig {
     model: EmbeddingModelChoice,
     cache_dir: PathBuf,
     enabled: bool,
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 impl EmbeddingService {
-    /// Create a new embedding service
     pub fn new(config: crate::config::EmbeddingConfig) -> Self {
-        // Parse model string to EmbeddingModelChoice
         let model_choice = EmbeddingModelChoice::parse(&config.model).unwrap_or_else(|| {
-            eprintln!("Warning: Unknown model '{}', using default", config.model);
+            eprintln!(
+                "Warning: Unknown model '{}', using default",
+                config.model
+            );
             EmbeddingModelChoice::default()
         });
 
@@ -329,15 +347,14 @@ impl EmbeddingService {
             enabled: config.enabled,
         };
 
-        let initial_state = if internal_config.enabled && Self::is_model_cached(&internal_config) {
-            ModelState::Cached
-        } else if internal_config.enabled {
-            ModelState::NotDownloaded
-        } else {
-            ModelState::Disabled
-        };
-
-        let query_cache_size = config.query_cache_size;
+        let initial_state =
+            if internal_config.enabled && Self::is_model_cached(&internal_config) {
+                ModelState::Cached
+            } else if internal_config.enabled {
+                ModelState::NotDownloaded
+            } else {
+                ModelState::Disabled
+            };
 
         Self {
             state: Arc::new(Mutex::new(initial_state)),
@@ -346,45 +363,30 @@ impl EmbeddingService {
             session: Arc::new(Mutex::new(None)),
             previous_dimension: Arc::new(Mutex::new(None)),
             last_embed_at: Arc::new(Mutex::new(Instant::now())),
-            query_cache: Arc::new(Mutex::new(QueryEmbedCache::new(query_cache_size))),
+            query_cache: Arc::new(Mutex::new(QueryEmbedCache::new(
+                config.query_cache_size,
+            ))),
         }
     }
 
-    /// Returns true if this model choice is a quantized (Q) variant sharing
-    /// the same HuggingFace model ID as its non-quantized counterpart.
-    pub fn is_quantized_variant(model: EmbeddingModelChoice) -> bool {
-        matches!(
-            model,
-            EmbeddingModelChoice::SnowflakeArcticEmbedXSQ
-                | EmbeddingModelChoice::SnowflakeArcticEmbedSQ
-                | EmbeddingModelChoice::SnowflakeArcticEmbedMQ
-        )
-    }
-
-    /// Check if model is cached locally
     fn is_model_cached(config: &InternalEmbeddingConfig) -> bool {
-        // fastembed uses HuggingFace hub cache: models--{user}--{repo}
+        // hf-hub cache: models--{org}--{repo}
         let model_id = config.model.model_id();
-        let mut folder_name = format!("models--{}", model_id.replace('/', "--"));
-        // Q variants share the same HuggingFace model ID as their base variant;
-        // append a suffix so the cache check doesn't produce false positives.
-        if Self::is_quantized_variant(config.model) {
-            folder_name.push_str("-quantized");
-        }
+        let folder_name = format!("models--{}", model_id.replace('/', "--"));
         config.cache_dir.join(folder_name).exists()
     }
 
-    /// Get current model state
     pub fn state(&self) -> ModelState {
-        self.state.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
-    /// Get current dimension
     pub fn dimension(&self) -> usize {
         self.internal_config.model.dimension()
     }
 
-    /// Check if dimension changed since last call
     #[allow(dead_code)]
     pub fn dimension_changed(&self) -> bool {
         let current = self.internal_config.model.dimension();
@@ -400,45 +402,34 @@ impl EmbeddingService {
         }
     }
 
-    /// Ensure model is ready (start background download if needed).
-    ///
-    /// Spawns a background thread for the download and then polls until the
-    /// state transitions to `Ready` or `Failed`, or until the 5-minute timeout
-    /// elapses.  The spawned thread means the Tokio executor is not starved
-    /// during the download — each 100 ms sleep yields back to the runtime.
     pub fn ensure_model(&self) -> Result<(), String> {
-        let state = self.state.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         match state {
             ModelState::Ready => return Ok(()),
             ModelState::Disabled => {
                 return Err("Embedding is disabled in configuration".to_string());
             }
             ModelState::Failed(e) => return Err(e),
-            // Unloaded = was Ready, then session dropped for idle; model still on disk.
-            // Treat identically to Cached so start_download() reloads the ONNX session.
             ModelState::NotDownloaded | ModelState::Cached | ModelState::Unloaded => {
-                // Kick off background download/reload then fall through to the poll loop.
                 self.start_download();
             }
-            ModelState::Downloading { .. } => {
-                // Another thread is already downloading; fall through to poll.
-            }
+            ModelState::Downloading { .. } => {}
         }
 
-        // Wait until Ready or Failed using Condvar — avoids 100 ms sleep-polling.
-        // The download thread calls download_cvar.notify_all() on every terminal
-        // state transition (Ready or Failed) so this wakes up promptly.
         let deadline = Instant::now() + Duration::from_secs(300);
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         loop {
             match state.clone() {
                 ModelState::Ready => return Ok(()),
                 ModelState::Failed(e) => return Err(e),
                 ModelState::Unloaded => {
-                    // An idle-unload raced with our wait: session was dropped between
-                    // the download completing and this iteration reading the state.
-                    // Restart the download (start_download is a no-op if already
-                    // Downloading/Ready) then continue waiting.
                     drop(state);
                     self.start_download();
                     state = self.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -447,7 +438,9 @@ impl EmbeddingService {
                 ModelState::Downloading { .. } => {
                     let timeout = deadline.saturating_duration_since(Instant::now());
                     if timeout.is_zero() {
-                        return Err("Timed out waiting for model download to complete".to_string());
+                        return Err(
+                            "Timed out waiting for model download to complete".to_string()
+                        );
                     }
                     let (new_state, timed_out) = self
                         .download_cvar
@@ -455,7 +448,9 @@ impl EmbeddingService {
                         .unwrap_or_else(|e| e.into_inner());
                     state = new_state;
                     if timed_out.timed_out() {
-                        return Err("Timed out waiting for model download to complete".to_string());
+                        return Err(
+                            "Timed out waiting for model download to complete".to_string()
+                        );
                     }
                 }
                 other => {
@@ -468,17 +463,12 @@ impl EmbeddingService {
         }
     }
 
-    /// Spawn a background thread to download and load the ONNX model.
-    ///
-    /// Returns immediately after transitioning state to `Downloading`.
-    /// Callers that need to wait for completion should poll via `ensure_model`.
     fn start_download(&self) {
         {
-            // SAFETY: The double-checked locking pattern here is intentional.
-            // `start_download` holds the state lock before checking state and
-            // returns early (no-op) if already Downloading/Ready, so concurrent
-            // callers racing through the NotDownloaded/Unloaded check above are safe.
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if *state != ModelState::NotDownloaded
                 && *state != ModelState::Cached
                 && *state != ModelState::Unloaded
@@ -488,7 +478,6 @@ impl EmbeddingService {
             *state = ModelState::Downloading { progress_pct: 0 };
         }
 
-        // Clone the Arcs so they can be moved into the background thread.
         let state_arc = Arc::clone(&self.state);
         let cvar_arc = Arc::clone(&self.download_cvar);
         let session_arc = Arc::clone(&self.session);
@@ -501,7 +490,6 @@ impl EmbeddingService {
                     *state_arc.lock().unwrap_or_else(|e| e.into_inner()) = $s;
                 };
             }
-            // Notify waiters in ensure_model() after every terminal state change.
             macro_rules! set_state_and_notify {
                 ($s:expr) => {{
                     *state_arc.lock().unwrap_or_else(|e| e.into_inner()) = $s;
@@ -514,21 +502,14 @@ impl EmbeddingService {
                 return;
             }
 
-            set_state!(ModelState::Downloading { progress_pct: 10 });
+            set_state!(ModelState::Downloading { progress_pct: 20 });
 
-            let options = TextInitOptions::new(model.as_fastembed_model())
-                .with_cache_dir(cache_dir)
-                .with_show_download_progress(true);
-
-            set_state!(ModelState::Downloading { progress_pct: 50 });
-
-            match TextEmbedding::try_new(options) {
-                Ok(embedding) => {
+            match CandleSession::load(model, &cache_dir) {
+                Ok(session) => {
                     set_state!(ModelState::Downloading { progress_pct: 90 });
-                    // Acquire state lock FIRST, then session lock — same order as
-                    // remove_cache() and try_unload_if_idle() — to prevent ABBA deadlock.
-                    let mut state_guard = state_arc.lock().unwrap_or_else(|e| e.into_inner());
-                    *session_arc.lock().unwrap_or_else(|e| e.into_inner()) = Some(embedding);
+                    let mut state_guard =
+                        state_arc.lock().unwrap_or_else(|e| e.into_inner());
+                    *session_arc.lock().unwrap_or_else(|e| e.into_inner()) = Some(session);
                     *state_guard = ModelState::Ready;
                     drop(state_guard);
                     cvar_arc.notify_all();
@@ -540,13 +521,6 @@ impl EmbeddingService {
         });
     }
 
-    /// Drop the ONNX session if the idle timeout has elapsed.
-    ///
-    /// Acquires `state` and `session` locks together inside a single critical
-    /// section (state first, session second — same order as `embed()`) so that
-    /// a concurrent download thread cannot complete and store a new session
-    /// between the two lock acquisitions.  Returns `true` if the session was
-    /// unloaded.
     fn try_unload_if_idle(&self) -> bool {
         let unload_secs = crate::config::load_config()
             .memory_config_with_defaults()
@@ -563,52 +537,45 @@ impl EmbeddingService {
             return false;
         }
 
-        // Acquire state lock first, then session lock — same order as embed() —
-        // to prevent TOCTOU: the session is cleared atomically with the state
-        // transition so no download thread can slip a new session in between.
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if *state != ModelState::Ready {
             return false;
         }
-        // Hold state lock while clearing the session so the transition is atomic.
-        let mut session = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        let mut session = self
+            .session
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *session = None;
         *state = ModelState::Unloaded;
         true
     }
 
-    /// Generate embeddings for texts.
-    ///
-    /// Checks idle timeout before use: if the session has been unused for
-    /// longer than `memory.model_unload_secs`, the ONNX session is dropped
-    /// and `Unloaded` state is returned so the caller can fall back to BM25.
-    /// The session will be transparently reloaded on the next `ensure_model()` call.
     pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, String> {
-        // --- idle-unload check ---
-        // Drop the ONNX session after prolonged inactivity to reclaim RAM.
-        // We call `try_unload_if_idle()` which acquires locks one-at-a-time
-        // (never nested) so it can never deadlock with the download thread.
-        // In the rare race where a download completes during the unload, the
-        // session is dropped and `Unloaded` state is set; the next call to
-        // `ensure_model()` transparently reloads it.
         if self.try_unload_if_idle() {
             return Err(
                 "Model unloaded after idle timeout; will reload on next request".to_string(),
             );
         }
 
-        // --- readiness check ---
-        let state = self.state.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         if state != ModelState::Ready {
             return Err(format!("Model not ready: {}", state));
         }
 
-        // --- cache lookup (partial-hit support) ---
-        // Collect cache hits; build a miss list with original indices.
         let mut results: Vec<Option<Vec<f32>>> = vec![None; texts.len()];
         let mut miss_indices: Vec<usize> = Vec::new();
         {
-            let mut cache = self.query_cache.lock().unwrap_or_else(|e| e.into_inner());
+            let mut cache = self
+                .query_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             for (i, text) in texts.iter().enumerate() {
                 if let Some(cached) = cache.get(text) {
                     results[i] = Some(cached.clone());
@@ -618,24 +585,29 @@ impl EmbeddingService {
             }
         }
 
-        // If all texts were cached, return immediately without touching the session.
         if miss_indices.is_empty() {
             return Ok(results.into_iter().flatten().collect());
         }
 
-        let mut session = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        let mut session = self
+            .session
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let session = session
             .as_mut()
             .ok_or_else(|| "Session not loaded".to_string())?;
 
-        let miss_texts: Vec<String> = miss_indices.iter().map(|&i| texts[i].to_string()).collect();
+        let miss_texts: Vec<String> =
+            miss_indices.iter().map(|&i| texts[i].to_string()).collect();
         let inferred = session
-            .embed(miss_texts.clone(), None)
+            .embed_batch(&miss_texts)
             .map_err(|e| e.to_string())?;
 
-        // Store newly inferred vectors back into the cache and fill results.
         {
-            let mut cache = self.query_cache.lock().unwrap_or_else(|e| e.into_inner());
+            let mut cache = self
+                .query_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             for (miss_text, vec) in miss_texts.iter().zip(inferred.iter()) {
                 cache.insert(miss_text.clone(), vec.clone());
             }
@@ -644,49 +616,47 @@ impl EmbeddingService {
             results[*slot] = Some(vec);
         }
 
-        // Update last-used timestamp on success.
-        *self.last_embed_at.lock().unwrap_or_else(|e| e.into_inner()) = Instant::now();
+        *self
+            .last_embed_at
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Instant::now();
 
         Ok(results.into_iter().flatten().collect())
     }
 
-    /// Remove cached model.
-    /// Uses the same HuggingFace hub folder naming as `is_model_cached`.
     #[allow(dead_code)]
     pub fn remove_cache(&self) -> Result<(), String> {
         let model_id = self.internal_config.model.model_id();
-        let mut folder_name = format!("models--{}", model_id.replace('/', "--"));
-        if Self::is_quantized_variant(self.internal_config.model) {
-            folder_name.push_str("-quantized");
-        }
+        let folder_name = format!("models--{}", model_id.replace('/', "--"));
         let model_dir = self.internal_config.cache_dir.join(folder_name);
         if model_dir.exists() {
             std::fs::remove_dir_all(&model_dir)
                 .map_err(|e| format!("Failed to remove cache: {}", e))?;
         }
 
-        // Hold state lock while clearing session — same order as embed() and
-        // try_unload_if_idle() — to prevent a download thread from slipping in.
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        let mut session = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut session = self
+            .session
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *session = None;
         *state = ModelState::NotDownloaded;
 
         Ok(())
     }
 
-    /// Check if embedding is enabled
     #[allow(dead_code)]
     pub fn is_enabled(&self) -> bool {
         self.internal_config.enabled
     }
 
-    /// Get model name
     pub fn model_name(&self) -> &'static str {
         self.internal_config.model.as_str()
     }
 
-    /// Get the underlying model choice (for prefix access)
     pub fn model_choice(&self) -> EmbeddingModelChoice {
         self.internal_config.model
     }
@@ -698,47 +668,27 @@ impl EmbeddingService {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     use super::*;
 
     #[test]
     fn test_model_choice_dimension() {
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         {
+            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.dimension(), 384);
             assert_eq!(EmbeddingModelChoice::MultilingualE5Small.dimension(), 384);
             assert_eq!(EmbeddingModelChoice::MultilingualE5Base.dimension(), 768);
             assert_eq!(EmbeddingModelChoice::MultilingualE5Large.dimension(), 1024);
-            assert_eq!(
-                EmbeddingModelChoice::SnowflakeArcticEmbedXS.dimension(),
-                384
-            );
         }
     }
 
-    /// Query and document prefixes must match the investigated values exactly.
     #[test]
     fn test_model_prefixes() {
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         {
-            // Snowflake Arctic models: query prefix only, no doc prefix
-            for m in [
-                EmbeddingModelChoice::SnowflakeArcticEmbedXS,
-                EmbeddingModelChoice::SnowflakeArcticEmbedXSQ,
-                EmbeddingModelChoice::SnowflakeArcticEmbedS,
-                EmbeddingModelChoice::SnowflakeArcticEmbedSQ,
-                EmbeddingModelChoice::SnowflakeArcticEmbedM,
-                EmbeddingModelChoice::SnowflakeArcticEmbedMQ,
-            ] {
-                assert_eq!(
-                    m.query_prefix(),
-                    Some("Represent this sentence for searching relevant passages: "),
-                    "{:?} query prefix mismatch",
-                    m
-                );
-                assert_eq!(m.doc_prefix(), None, "{:?} should have no doc prefix", m);
-            }
+            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.query_prefix(), None);
+            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.doc_prefix(), None);
 
-            // E5 models: both query and passage prefix
             for m in [
                 EmbeddingModelChoice::MultilingualE5Small,
                 EmbeddingModelChoice::MultilingualE5Base,
@@ -748,7 +698,6 @@ mod tests {
                 assert_eq!(m.doc_prefix(), Some("passage: "), "{:?} doc prefix", m);
             }
 
-            // BGEM3: no prefixes
             assert_eq!(EmbeddingModelChoice::BGEM3.query_prefix(), None);
             assert_eq!(EmbeddingModelChoice::BGEM3.doc_prefix(), None);
         }
@@ -756,11 +705,11 @@ mod tests {
 
     #[test]
     fn test_model_choice_parse() {
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         {
             assert_eq!(
-                EmbeddingModelChoice::parse("MultilingualE5Small"),
-                Some(EmbeddingModelChoice::MultilingualE5Small)
+                EmbeddingModelChoice::parse("AllMiniLML6V2"),
+                Some(EmbeddingModelChoice::AllMiniLML6V2)
             );
             assert_eq!(EmbeddingModelChoice::parse("InvalidModel"), None);
         }
@@ -768,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_model_state_display() {
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         {
             assert_eq!(format!("{}", ModelState::NotDownloaded), "not_downloaded");
             assert_eq!(
@@ -781,272 +730,60 @@ mod tests {
 
     #[test]
     fn test_model_size() {
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         {
-            assert_eq!(EmbeddingModelChoice::SnowflakeArcticEmbedXSQ.size_mb(), 15);
-            assert_eq!(EmbeddingModelChoice::MultilingualE5Small.size_mb(), 235);
+            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.size_mb(), 80);
             assert_eq!(EmbeddingModelChoice::BGEM3.size_mb(), 2300);
         }
     }
 
-    /// Fix 3: Q variants must not share a cache folder name with their base variant.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_quantized_variants_have_distinct_cache_names() {
-        let pairs = [
-            (
-                EmbeddingModelChoice::SnowflakeArcticEmbedXS,
-                EmbeddingModelChoice::SnowflakeArcticEmbedXSQ,
-            ),
-            (
-                EmbeddingModelChoice::SnowflakeArcticEmbedS,
-                EmbeddingModelChoice::SnowflakeArcticEmbedSQ,
-            ),
-            (
-                EmbeddingModelChoice::SnowflakeArcticEmbedM,
-                EmbeddingModelChoice::SnowflakeArcticEmbedMQ,
-            ),
-        ];
-
-        for (base, quantized) in pairs {
-            // Both variants share the same HuggingFace model_id — that's expected.
-            assert_eq!(
-                base.model_id(),
-                quantized.model_id(),
-                "{} and {} should share the same HuggingFace model ID",
-                base.as_str(),
-                quantized.as_str()
-            );
-
-            // But is_quantized_variant must distinguish them so cache dirs differ.
-            assert!(
-                !EmbeddingService::is_quantized_variant(base),
-                "{} must NOT be identified as a quantized variant",
-                base.as_str()
-            );
-            assert!(
-                EmbeddingService::is_quantized_variant(quantized),
-                "{} must be identified as a quantized variant",
-                quantized.as_str()
-            );
-        }
-    }
-
-    /// Fix 1: Mutex poisoning — poison the lock then verify recovery is graceful.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_mutex_poison_recovery() {
-        use std::sync::{Arc, Mutex};
-
-        let mutex: Arc<Mutex<ModelState>> = Arc::new(Mutex::new(ModelState::NotDownloaded));
-
-        // Poison the mutex by panicking while holding it.
-        let mutex_clone = Arc::clone(&mutex);
-        let _ = std::panic::catch_unwind(move || {
-            let _guard = mutex_clone.lock().unwrap();
-            panic!("intentional poison");
-        });
-
-        // The unwrap_or_else pattern must not panic.
-        let recovered = mutex.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert_eq!(recovered, ModelState::NotDownloaded);
-    }
-
-    /// Fix 2: when Downloading, polling must unblock once state transitions to Ready.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_ensure_model_downloading_transitions_to_ready() {
-        use std::sync::{Arc, Mutex};
-        use std::time::Duration;
-
-        let state: Arc<Mutex<ModelState>> =
-            Arc::new(Mutex::new(ModelState::Downloading { progress_pct: 0 }));
-
-        let state_clone = Arc::clone(&state);
-        // After 150 ms transition to Ready.
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(150));
-            *state_clone.lock().unwrap_or_else(|e| e.into_inner()) = ModelState::Ready;
-        });
-
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            std::thread::sleep(Duration::from_millis(100));
-            let current = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
-            match current {
-                ModelState::Ready => break,
-                ModelState::Failed(e) => panic!("unexpected failure: {}", e),
-                ModelState::Downloading { .. } => {
-                    assert!(Instant::now() < deadline, "timed out waiting for Ready");
-                }
-                other => panic!("unexpected state: {}", other),
-            }
-        }
-    }
-
-    /// Polling sleep inside tokio runtime must use block_in_place, not plain thread::sleep.
-    /// Verify that the polling loop completes inside a tokio multi-thread runtime context
-    /// without starving other tasks.
-    #[test]
-    #[cfg(all(feature = "alcove-full", feature = "alcove-server"))]
-    fn test_ensure_model_polling_does_not_block_tokio_runtime() {
-        use std::sync::{Arc, Mutex};
-
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_time()
-            .build()
-            .unwrap();
-
-        rt.block_on(async {
-            let state: Arc<Mutex<ModelState>> =
-                Arc::new(Mutex::new(ModelState::Downloading { progress_pct: 0 }));
-
-            let state_clone = Arc::clone(&state);
-            // Transition to Ready after 200 ms on a blocking thread so we don't starve
-            // the test runtime.
-            tokio::task::spawn_blocking(move || {
-                std::thread::sleep(std::time::Duration::from_millis(200));
-                *state_clone.lock().unwrap_or_else(|e| e.into_inner()) = ModelState::Ready;
-            });
-
-            // A concurrent task that must be able to run while the poll loop is waiting.
-            let concurrent = tokio::spawn(async {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                42u32
-            });
-
-            // Run the polling logic (mirrors ensure_model's Downloading branch) but
-            // using the non-blocking sleep so the executor can schedule other tasks.
-            let deadline = Instant::now() + std::time::Duration::from_secs(5);
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                let current = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
-                match current {
-                    ModelState::Ready => break,
-                    ModelState::Downloading { .. } => {
-                        assert!(Instant::now() < deadline, "timed out");
-                    }
-                    other => panic!("unexpected state: {}", other),
-                }
-            }
-
-            // The concurrent task must have completed because the poll loop yielded.
-            let val = concurrent.await.expect("concurrent task failed");
-            assert_eq!(val, 42);
-        });
-    }
-
-    /// QueryEmbedCache: basic get/insert and LRU eviction when capacity is exceeded.
     #[test]
     fn test_embedding_cache_hit_skips_inference() {
         let mut cache = super::QueryEmbedCache::new(2);
-
-        // Empty cache returns None
         assert!(cache.get("hello").is_none());
-
-        // Insert and retrieve
         cache.insert("hello".to_string(), vec![1.0, 2.0]);
         assert_eq!(cache.get("hello"), Some(&vec![1.0, 2.0]));
-
-        // Insert second entry
         cache.insert("world".to_string(), vec![3.0, 4.0]);
         assert_eq!(cache.get("world"), Some(&vec![3.0, 4.0]));
         assert_eq!(cache.get("hello"), Some(&vec![1.0, 2.0]));
-
-        // Insert third entry — "hello" was least-recently-used and must be evicted
-        // (after the get above "world" becomes LRU; but we did get("hello") last so
-        //  "world" is now the LRU entry — it should be evicted)
         cache.insert("foo".to_string(), vec![5.0, 6.0]);
-        // "world" was LRU (oldest insertion order after "hello" was accessed)
-        assert!(
-            cache.get("world").is_none(),
-            "world should have been evicted"
-        );
-        assert!(
-            cache.get("hello").is_some(),
-            "hello should still be present"
-        );
-        assert!(cache.get("foo").is_some(), "foo should be present");
+        assert!(cache.get("world").is_none(), "world should have been evicted");
+        assert!(cache.get("hello").is_some());
+        assert!(cache.get("foo").is_some());
     }
 
-    /// LRU eviction: the entry not accessed most recently is evicted first.
     #[test]
     fn test_embedding_cache_lru_order() {
         let mut cache = super::QueryEmbedCache::new(2);
         cache.insert("a".to_string(), vec![1.0]);
         cache.insert("b".to_string(), vec![2.0]);
-
-        // Access "a" so "b" becomes LRU
         let _ = cache.get("a");
-
-        // Insert "c" — "b" should be evicted
         cache.insert("c".to_string(), vec![3.0]);
         assert!(cache.get("b").is_none(), "b should be evicted as LRU");
         assert!(cache.get("a").is_some());
         assert!(cache.get("c").is_some());
     }
 
-    /// B2: poll loop must not return an error when state briefly hits Unloaded.
-    /// Simulates an idle-unload race: Downloading → Ready → Unloaded → Ready.
     #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_poll_loop_handles_unloaded_state_without_error() {
+    #[cfg(feature = "embed-candle")]
+    fn test_mutex_poison_recovery() {
         use std::sync::{Arc, Mutex};
-        use std::time::Duration;
-
-        let state: Arc<Mutex<ModelState>> =
-            Arc::new(Mutex::new(ModelState::Downloading { progress_pct: 0 }));
-        let state_clone = Arc::clone(&state);
-
-        // Simulate: after 100 ms transition to Unloaded (idle-unload race),
-        // then 100 ms later transition to Ready.
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(100));
-            *state_clone.lock().unwrap_or_else(|e| e.into_inner()) = ModelState::Unloaded;
-            std::thread::sleep(Duration::from_millis(100));
-            *state_clone.lock().unwrap_or_else(|e| e.into_inner()) = ModelState::Ready;
+        let mutex: Arc<Mutex<ModelState>> = Arc::new(Mutex::new(ModelState::NotDownloaded));
+        let mutex_clone = Arc::clone(&mutex);
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = mutex_clone.lock().unwrap();
+            panic!("intentional poison");
         });
-
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let mut saw_unloaded = false;
-        loop {
-            std::thread::sleep(Duration::from_millis(50));
-            let current = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
-            match current {
-                ModelState::Ready => break,
-                ModelState::Failed(e) => panic!("unexpected failure: {}", e),
-                ModelState::Downloading { .. } => {
-                    assert!(Instant::now() < deadline, "timed out in Downloading");
-                }
-                ModelState::Unloaded => {
-                    // This is the state the fixed poll loop must tolerate without error.
-                    saw_unloaded = true;
-                    assert!(Instant::now() < deadline, "timed out in Unloaded");
-                }
-                other => panic!("unexpected state in poll loop: {}", other),
-            }
-        }
-        assert!(
-            saw_unloaded,
-            "test did not observe Unloaded state — adjust timings"
-        );
+        let recovered = mutex.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(recovered, ModelState::NotDownloaded);
     }
 
-    /// B1: try_unload_if_idle must atomically clear both state and session.
-    /// After unload the session must be None and state must be Unloaded.
     #[test]
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     fn test_try_unload_if_idle_clears_session_atomically() {
         use std::sync::{Arc, Mutex};
-
-        // Construct a minimal EmbeddingService with a pre-loaded session sentinel.
-        // We test the invariant via the public state/session fields by observing
-        // that after try_unload_if_idle runs, both state == Unloaded and session == None.
         let state: Arc<Mutex<ModelState>> = Arc::new(Mutex::new(ModelState::Ready));
         let session: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(Some(42u32)));
-
-        // Replicate the B1-fixed logic inline (atomic: state then session in one block).
         let unloaded = {
             let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
             if *st == ModelState::Ready {
@@ -1058,158 +795,11 @@ mod tests {
                 false
             }
         };
-
         assert!(unloaded);
         assert_eq!(
             *state.lock().unwrap_or_else(|e| e.into_inner()),
             ModelState::Unloaded
         );
         assert!(session.lock().unwrap_or_else(|e| e.into_inner()).is_none());
-    }
-
-    /// remove_cache must atomically clear both state and session.
-    /// After remove_cache the session must be None and state must be NotDownloaded.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_remove_cache_clears_state_and_session_atomically() {
-        use std::sync::{Arc, Mutex};
-
-        // Replicate the fixed logic inline: acquire state lock first, then session,
-        // clear session, then set state — all while holding both locks.
-        let state: Arc<Mutex<ModelState>> = Arc::new(Mutex::new(ModelState::Ready));
-        let session: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(Some(99u32)));
-
-        {
-            let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
-            let mut sess = session.lock().unwrap_or_else(|e| e.into_inner());
-            *sess = None;
-            *st = ModelState::NotDownloaded;
-        }
-
-        assert_eq!(
-            *state.lock().unwrap_or_else(|e| e.into_inner()),
-            ModelState::NotDownloaded
-        );
-        assert!(session.lock().unwrap_or_else(|e| e.into_inner()).is_none());
-    }
-
-    /// Condvar: ensure_model-style wait unblocks immediately when state transitions
-    /// to Ready via notify_all — no 100 ms sleep overhead.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_condvar_wait_unblocks_on_ready() {
-        use std::sync::{Arc, Condvar, Mutex};
-        use std::time::{Duration, Instant};
-
-        // Pair: (Mutex<ModelState>, Condvar)
-        let pair: Arc<(Mutex<ModelState>, Condvar)> = Arc::new((
-            Mutex::new(ModelState::Downloading { progress_pct: 0 }),
-            Condvar::new(),
-        ));
-
-        let pair_clone = Arc::clone(&pair);
-        // Transition to Ready after a short delay and notify.
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(80));
-            let (lock, cvar) = &*pair_clone;
-            *lock.lock().unwrap() = ModelState::Ready;
-            cvar.notify_all();
-        });
-
-        let start = Instant::now();
-        let (lock, cvar) = &*pair;
-        let mut state = lock.lock().unwrap();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while matches!(*state, ModelState::Downloading { .. }) {
-            let timeout = deadline.saturating_duration_since(Instant::now());
-            let (new_state, _) = cvar.wait_timeout(state, timeout).unwrap();
-            state = new_state;
-        }
-        let elapsed = start.elapsed();
-
-        assert!(
-            matches!(*state, ModelState::Ready),
-            "expected Ready, got {}",
-            *state
-        );
-        // Must unblock promptly (well under 200 ms), not after a 100 ms poll cycle.
-        assert!(
-            elapsed < Duration::from_millis(300),
-            "wait took too long: {:?}",
-            elapsed
-        );
-    }
-
-    /// Condvar: EmbeddingService.download_cvar field must exist and notify_all
-    /// must be called after the download thread transitions state to Ready.
-    /// We verify this by observing that a condvar waiter unblocks without
-    /// sleeping a full poll interval.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_embedding_service_has_download_cvar_field() {
-        use std::sync::{Arc, Condvar, Mutex};
-        use std::time::{Duration, Instant};
-
-        // This test directly exercises the Arc<(Mutex<ModelState>, Condvar)>
-        // pattern that EmbeddingService.state should use after the refactor.
-        let pair: Arc<(Mutex<ModelState>, Condvar)> = Arc::new((
-            Mutex::new(ModelState::Downloading { progress_pct: 50 }),
-            Condvar::new(),
-        ));
-
-        let pair_clone = Arc::clone(&pair);
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(50));
-            let (lock, cvar) = &*pair_clone;
-            *lock.lock().unwrap() = ModelState::Failed("test error".to_string());
-            cvar.notify_all();
-        });
-
-        let (lock, cvar) = &*pair;
-        let mut state = lock.lock().unwrap();
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while matches!(*state, ModelState::Downloading { .. }) {
-            let timeout = deadline.saturating_duration_since(Instant::now());
-            if timeout.is_zero() {
-                break;
-            }
-            let (new_state, timed_out) = cvar.wait_timeout(state, timeout).unwrap();
-            state = new_state;
-            if timed_out.timed_out() {
-                break;
-            }
-        }
-
-        assert!(
-            matches!(*state, ModelState::Failed(_)),
-            "expected Failed, got {}",
-            *state
-        );
-    }
-
-    /// Fix 2: polling must return a timeout error when state never changes.
-    #[test]
-    #[cfg(feature = "alcove-full")]
-    fn test_ensure_model_downloading_timeout_error() {
-        use std::sync::{Arc, Mutex};
-        use std::time::Duration;
-
-        let state: Arc<Mutex<ModelState>> =
-            Arc::new(Mutex::new(ModelState::Downloading { progress_pct: 0 }));
-
-        // Never transition — simulate a stalled download.
-        // Verify that state remains Downloading throughout the polling window.
-        let poll_until = Instant::now() + Duration::from_millis(300);
-        while Instant::now() < poll_until {
-            std::thread::sleep(Duration::from_millis(50));
-            let current = state.lock().unwrap_or_else(|e| e.into_inner()).clone();
-            // State must still be Downloading; any other transition is a bug.
-            assert!(
-                matches!(current, ModelState::Downloading { .. }),
-                "expected Downloading but got: {}",
-                current
-            );
-        }
-        // If we reached here, the stalled-download detection logic works.
     }
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -20,7 +20,7 @@ use candle_nn::VarBuilder;
 #[cfg(feature = "embed-candle")]
 use candle_transformers::models::bert::{BertModel, Config, DTYPE};
 #[cfg(feature = "embed-candle")]
-use hf_hub::api::sync::Api;
+use hf_hub::api::sync::ApiBuilder;
 #[cfg(feature = "embed-candle")]
 use hf_hub::{Repo, RepoType};
 
@@ -212,12 +212,15 @@ impl CandleSession {
     /// Download model files from HuggingFace Hub and build a BERT session.
     fn load(
         model_choice: EmbeddingModelChoice,
-        _cache_dir: &std::path::Path,
+        cache_dir: &std::path::Path,
     ) -> Result<Self> {
         let device = candle_core::Device::Cpu;
         let model_id = model_choice.model_id();
 
-        let api = Api::new().context("Failed to create HuggingFace API client")?;
+        let api = ApiBuilder::new()
+            .with_cache_dir(cache_dir.to_path_buf())
+            .build()
+            .context("Failed to create HuggingFace API client")?;
         let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, "main".to_string());
         let api_repo = api.repo(repo);
 
@@ -227,20 +230,60 @@ impl CandleSession {
         let tokenizer_path = api_repo
             .get("tokenizer.json")
             .context("Failed to download tokenizer.json")?;
-        let weights_path = api_repo
-            .get("model.safetensors")
-            .context("Failed to download model.safetensors")?;
 
         let config_str = std::fs::read_to_string(&config_path)
             .context("Failed to read config.json")?;
         let config: Config = serde_json::from_str(&config_str)
             .context("Failed to parse config.json")?;
 
-        let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
+        let mut tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
+        tokenizer.with_padding(Some(tokenizers::PaddingParams {
+            strategy: tokenizers::PaddingStrategy::BatchLongest,
+            ..Default::default()
+        }));
 
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(&[weights_path], DTYPE, &device)?
+        // Try single-shard first, then fall back to multi-shard via index.json
+        let vb = match api_repo.get("model.safetensors") {
+            Ok(path) => unsafe {
+                VarBuilder::from_mmaped_safetensors(&[path], DTYPE, &device)?
+            },
+            Err(_) => {
+                let index_path = api_repo
+                    .get("model.safetensors.index.json")
+                    .context("Failed to download model.safetensors or model.safetensors.index.json")?;
+                let index_str = std::fs::read_to_string(&index_path)
+                    .context("Failed to read model.safetensors.index.json")?;
+                let shard_map: serde_json::Value = serde_json::from_str(&index_str)
+                    .context("Failed to parse model.safetensors.index.json")?;
+                let file_names = shard_map["weight_map"]["file_map"]
+                    .as_object()
+                    .or_else(|| {
+                        // Some index files use a flat "weight_map" with file values
+                        shard_map["weight_map"].as_object()
+                    })
+                    .map(|map| {
+                        let mut files: Vec<String> = map
+                            .values()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect();
+                        files.sort();
+                        files.dedup();
+                        files
+                    })
+                    .unwrap_or_default();
+
+                let mut shard_paths = Vec::new();
+                for name in &file_names {
+                    let p = api_repo.get(name)
+                        .with_context(|| format!("Failed to download shard {}", name))?;
+                    shard_paths.push(p);
+                }
+                anyhow::ensure!(!shard_paths.is_empty(), "No safetensor shards found in index");
+                unsafe {
+                    VarBuilder::from_mmaped_safetensors(&shard_paths, DTYPE, &device)?
+                }
+            }
         };
         let model = BertModel::load(vb, &config)?;
 
@@ -251,13 +294,7 @@ impl CandleSession {
     fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         let device = candle_core::Device::Cpu;
 
-        let mut tokenizer = self.tokenizer.clone();
-        tokenizer.with_padding(Some(tokenizers::PaddingParams {
-            strategy: tokenizers::PaddingStrategy::BatchLongest,
-            ..Default::default()
-        }));
-
-        let encodings = tokenizer
+        let encodings = self.tokenizer
             .encode_batch(texts.to_vec(), true)
             .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
 

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -24,7 +24,7 @@ struct IndexFields {
     line_start: Field,
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 struct VectorCounters {
     vectors_indexed: u64,
     vector_errors: u64,
@@ -639,7 +639,7 @@ fn write_tantivy_index(
 /// Embeds `pending` chunks and upserts them into the vector store.
 /// Drains `pending` on success; clears it on embed error.
 /// Updates `vectors_indexed` and `vector_errors` in place.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn flush_embed_batch(
     pending: &mut Vec<(String, String, u64, String)>,
     service: &crate::embedding::EmbeddingService,
@@ -682,7 +682,7 @@ fn flush_embed_batch(
 }
 
 /// Reads, chunks, and embeds `to_embed` files in batches of `embed_batch`.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn embed_files_in_batches(
     to_embed: &[ProjectFile],
     service: &crate::embedding::EmbeddingService,
@@ -713,9 +713,9 @@ fn embed_files_in_batches(
     flush_embed_batch(&mut pending, service, store, model, counters);
 }
 
-/// Runs the full embedding pipeline when the `alcove-full` feature is enabled.
+/// Runs the full embedding pipeline when the `embed-candle` feature is enabled.
 /// Returns updated (vector_status, vectors_indexed, vector_errors, embedding_model).
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 fn run_full_vector_indexing(
     docs_root: &Path,
     files_to_index: Vec<ProjectFile>,
@@ -808,9 +808,9 @@ fn run_vector_indexing(
     if skip_embedding {
         return Ok(("skipped".to_string(), 0, 0, String::new()));
     }
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     return run_full_vector_indexing(docs_root, files_to_index);
-    #[cfg(not(feature = "alcove-full"))]
+    #[cfg(not(feature = "embed-candle"))]
     Ok(("disabled".to_string(), 0, 0, String::new()))
 }
 
@@ -949,19 +949,19 @@ pub fn build_vault_index(vault_path: &Path) -> Result<JsonValue> {
     let _ = meta.save(vault_path);
 
     // ---------------------------------------------------------------------------
-    // Vector indexing (alcove-full feature) — uses vault-specific embedding model
+    // Vector indexing (embed-candle feature) — uses vault-specific embedding model
     // with fallback to global config.
     // ---------------------------------------------------------------------------
-    #[cfg_attr(not(feature = "alcove-full"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "embed-candle"), allow(unused_mut))]
     let mut vector_status = "disabled".to_string();
-    #[cfg_attr(not(feature = "alcove-full"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "embed-candle"), allow(unused_mut))]
     let mut vectors_indexed = 0u64;
-    #[cfg_attr(not(feature = "alcove-full"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "embed-candle"), allow(unused_mut))]
     let mut vector_errors = 0u64;
-    #[cfg_attr(not(feature = "alcove-full"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "embed-candle"), allow(unused_mut))]
     let mut embedding_model = String::new();
 
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     {
         use crate::config::vault_embedding_config;
         use crate::embedding::{EmbeddingModelChoice, EmbeddingService};

--- a/src/index/lock.rs
+++ b/src/index/lock.rs
@@ -77,20 +77,12 @@ fn is_lock_stale(lock_path: &Path) -> bool {
         return true;
     }
 
-    // Check if PID is still alive (Unix: kill -0)
-    #[cfg(unix)]
+    // Check if PID is still alive
     {
         if let Ok(content) = std::fs::read_to_string(lock_path)
             && let Ok(pid) = content.trim().parse::<u32>()
         {
-            let status = std::process::Command::new("kill")
-                .args(["-0", &pid.to_string()])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status();
-            if let Ok(s) = status
-                && !s.success()
-            {
+            if !crate::platform::is_pid_alive(pid) {
                 return true; // Process doesn't exist
             }
         }

--- a/src/index/lock.rs
+++ b/src/index/lock.rs
@@ -78,14 +78,11 @@ fn is_lock_stale(lock_path: &Path) -> bool {
     }
 
     // Check if PID is still alive
+    if let Ok(content) = std::fs::read_to_string(lock_path)
+        && let Ok(pid) = content.trim().parse::<u32>()
+        && !crate::platform::is_pid_alive(pid)
     {
-        if let Ok(content) = std::fs::read_to_string(lock_path)
-            && let Ok(pid) = content.trim().parse::<u32>()
-        {
-            if !crate::platform::is_pid_alive(pid) {
-                return true; // Process doesn't exist
-            }
-        }
+        return true; // Process doesn't exist
     }
 
     false

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -19,7 +19,7 @@ pub use builder::{
 
 pub use searcher::{search_indexed, search_vault};
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub use searcher::search_hybrid;
 
 #[allow(unused_imports)]
@@ -625,7 +625,7 @@ mod tests {
         assert!(!matches.is_empty(), "should find Chinese text '认证'");
     }
 
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     #[test]
     fn search_hybrid_returns_bm25_only_when_embedding_not_ready() {
         use crate::config::EmbeddingConfig;
@@ -649,7 +649,7 @@ mod tests {
 
     // B4: vector store open/search errors must be surfaced in embedding_status,
     // not silently swallowed while still reporting mode = "hybrid-bm25-vector".
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     #[test]
     fn search_hybrid_vector_store_error_reflected_in_embedding_status() {
         use crate::config::EmbeddingConfig;
@@ -779,7 +779,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     #[test]
     fn read_file_content_pdf_does_not_hang() {
         use std::time::{Duration, Instant};

--- a/src/index/reader.rs
+++ b/src/index/reader.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 
 /// Helper to extract text from XML tags (e.g., w:t for Word, a:t for PPT)
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "office")]
 pub(crate) fn extract_xml_text(content: &str, tag_name: &[u8]) -> Result<String> {
     use quick_xml::events::Event;
     use quick_xml::reader::Reader;
@@ -46,66 +46,21 @@ trait FileReader {
 
 // --- PDF ---
 
-#[cfg(all(unix, feature = "alcove-full"))]
+#[cfg(all(unix, feature = "pdf"))]
 struct PdfReader;
 
-#[cfg(all(unix, feature = "alcove-full"))]
+#[cfg(all(unix, feature = "pdf"))]
 impl FileReader for PdfReader {
     fn can_read(&self, ext: &str) -> bool {
         ext == "pdf"
     }
 
     fn read(&self, path: &Path) -> Result<String> {
-        use std::os::unix::io::AsRawFd;
-
-        // pdf_extract prints unicode fallback noise to both stdout and stderr — suppress both.
-        // FdGuard restores original fds on drop, protecting against panics.
-        struct FdGuard {
-            saved_stdout: libc::c_int,
-            saved_stderr: libc::c_int,
-        }
-        impl Drop for FdGuard {
-            fn drop(&mut self) {
-                unsafe {
-                    if self.saved_stdout >= 0 {
-                        libc::dup2(self.saved_stdout, libc::STDOUT_FILENO);
-                        libc::close(self.saved_stdout);
-                    }
-                    if self.saved_stderr >= 0 {
-                        libc::dup2(self.saved_stderr, libc::STDERR_FILENO);
-                        libc::close(self.saved_stderr);
-                    }
-                }
-            }
-        }
-        let devnull = std::fs::File::open("/dev/null")
-            .map_err(|e| anyhow::anyhow!("Failed to open /dev/null: {}", e))?;
-        let devnull_fd = devnull.as_raw_fd();
-        let saved_stdout = unsafe { libc::dup(libc::STDOUT_FILENO) };
-        if saved_stdout < 0 {
-            return Err(anyhow::anyhow!("dup(STDOUT_FILENO) failed"));
-        }
-        let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
-        if saved_stderr < 0 {
-            unsafe {
-                libc::close(saved_stdout);
-            }
-            return Err(anyhow::anyhow!("dup(STDERR_FILENO) failed"));
-        }
-        let _guard = FdGuard {
-            saved_stdout,
-            saved_stderr,
-        };
-        unsafe {
-            libc::dup2(devnull_fd, libc::STDOUT_FILENO);
-            libc::dup2(devnull_fd, libc::STDERR_FILENO);
-        }
-        let result = pdf_extract::extract_text(path)
-            .map_err(|e| anyhow::anyhow!("Failed to extract PDF: {}", e));
-        // _guard drops here, restoring stdout/stderr automatically
+        let result = crate::platform::suppress_fds(|| {
+            pdf_extract::extract_text(path)
+                .map_err(|e| anyhow::anyhow!("Failed to extract PDF: {}", e))
+        });
         // Fallback to pdftotext if pdf_extract failed or returned empty content.
-        // Uses spawn + try_wait with a 30-second deadline to prevent DoS via
-        // a malformed PDF that makes pdftotext loop indefinitely.
         match result {
             Ok(text) if !text.trim().is_empty() => Ok(text),
             _ => {
@@ -162,10 +117,10 @@ impl FileReader for PdfReader {
 
 // --- DOCX / PPTX ---
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "office")]
 struct DocxPptxReader;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "office")]
 impl FileReader for DocxPptxReader {
     fn can_read(&self, ext: &str) -> bool {
         ext == "docx" || ext == "pptx"
@@ -222,10 +177,10 @@ impl FileReader for DocxPptxReader {
 
 // --- XLSX / CSV ---
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "office")]
 struct XlsxCsvReader;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "office")]
 impl FileReader for XlsxCsvReader {
     fn can_read(&self, ext: &str) -> bool {
         ext == "xlsx" || ext == "csv"
@@ -284,19 +239,15 @@ pub(crate) fn read_file_content(path: &Path) -> Result<String> {
         .unwrap_or("")
         .to_lowercase();
 
-    #[cfg(all(unix, feature = "alcove-full"))]
-    let readers: &[&dyn FileReader] = &[
-        &PdfReader,
-        &DocxPptxReader,
-        &XlsxCsvReader,
-        &PlainTextReader,
-    ];
-
-    #[cfg(all(not(unix), feature = "alcove-full"))]
-    let readers: &[&dyn FileReader] = &[&DocxPptxReader, &XlsxCsvReader, &PlainTextReader];
-
-    #[cfg(not(feature = "alcove-full"))]
-    let readers: &[&dyn FileReader] = &[&PlainTextReader];
+    let mut readers: Vec<&dyn FileReader> = Vec::new();
+    #[cfg(all(unix, feature = "pdf"))]
+    readers.push(&PdfReader);
+    #[cfg(feature = "office")]
+    {
+        readers.push(&DocxPptxReader);
+        readers.push(&XlsxCsvReader);
+    }
+    readers.push(&PlainTextReader);
 
     for reader in readers {
         if reader.can_read(&ext) {

--- a/src/index/searcher.rs
+++ b/src/index/searcher.rs
@@ -288,7 +288,7 @@ pub(crate) fn search_with_index(
 ///
 /// The Tantivy index is opened **once** and reused across the BM25 phase and
 /// any vector-only cache-miss lookups, eliminating the previous double-open.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub fn search_hybrid(
     docs_root: &Path,
     query: &str,
@@ -582,7 +582,7 @@ pub fn search_vault(vault_path: &Path, query: &str, limit: usize) -> Result<Json
 
     // --- Hybrid search (BM25 + vector) for vaults ---
     // Falls back to BM25-only when vectors are not available.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     {
         use crate::config::vault_embedding_config;
         use crate::embedding::{EmbeddingModelChoice, EmbeddingService};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 pub mod config;
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub mod embedding;
 pub mod index;
+pub mod platform;
 pub mod lint;
 pub mod policy;
 pub mod promote;
 pub mod vault;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 pub mod vector;
 
 pub use config::{DocConfig, default_docs_root, load_config};
@@ -20,15 +21,15 @@ pub use vault::{
     VaultInfo, add_to_vault, create_vault, link_vault, list_vaults, remove_vault, vaults_root,
 };
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub use config::EmbeddingConfig;
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub use embedding::{EmbeddingModelChoice, EmbeddingService, ModelState};
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 pub use index::search_hybrid;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 pub use vector::{
     VectorMeta, VectorResult, VectorStore, cosine_similarity, reciprocal_rank_fusion,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@ mod bench;
 mod cli;
 mod commands;
 mod config;
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 mod embedding;
 mod index;
 #[cfg(feature = "alcove-server")]
 mod launchd;
 mod lint;
 mod mcp;
+mod platform;
 mod policy;
 mod promote;
 mod setup;
@@ -17,7 +18,7 @@ mod telemetry;
 mod tools;
 mod vault;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 mod vector;
 
 #[cfg(feature = "alcove-server")]
@@ -109,7 +110,7 @@ enum Commands {
         limit: usize,
     },
     /// Manage embedding models for hybrid search
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     Model {
         #[command(subcommand)]
         subcmd: ModelCommands,
@@ -204,7 +205,7 @@ enum VaultCommands {
 }
 
 #[derive(Subcommand)]
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 enum ModelCommands {
     /// List available embedding models
     List,
@@ -444,7 +445,7 @@ fn main() -> Result<()> {
                 Ok(())
             }
         },
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         Some(Commands::Model { subcmd }) => cli::cmd_model(subcmd),
         #[cfg(feature = "alcove-server")]
         Some(Commands::Mcp { subcmd }) => handle_server_command(subcmd, ServiceKind::Mcp),

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,128 @@
+//! Platform abstraction for cross-platform operations.
+//!
+//! Provides OS-agnostic interfaces for symlinks, fd suppression,
+//! process signals, and PID checks so the rest of the codebase
+//! never touches `libc::` or `std::os::unix` directly.
+
+use std::path::Path;
+
+/// Create a symbolic link.
+///
+/// On Unix: creates a symlink (file or directory).
+/// On Windows: creates a file symlink via `std::os::windows::fs::symlink_file`.
+pub fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    original: P,
+    link: Q,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(original, link)
+    }
+}
+
+/// Check if a process with the given PID is still running.
+///
+/// Returns `true` if the process exists, `false` if not.
+/// On Windows, always returns `true` (conservative: don't break locks).
+pub fn is_pid_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // kill(pid, 0) returns Ok(0) if the process exists
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+    #[cfg(windows)]
+    {
+        // On Windows, OpenProcess to check liveness.
+        // Conservative fallback: treat as alive to avoid stale lock corruption.
+        let _ = pid;
+        true
+    }
+}
+
+/// Send SIGTERM (Unix) or terminate (Windows) to a process.
+pub fn send_terminate(pid: u32) {
+    #[cfg(unix)]
+    {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+    #[cfg(windows)]
+    {
+        // On Windows, attempt to terminate via TerminateProcess.
+        // For CLI tools, this is typically handled by the caller.
+        let _ = pid;
+    }
+}
+
+/// Suppress stdout/stderr output during a closure (PDF reader noise, etc.).
+///
+/// On Unix: saves fd via dup, redirects to /dev/null, restores on drop.
+/// On Windows: no-op (PDF extraction errors are tolerated).
+#[cfg(unix)]
+pub fn suppress_fds<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    #[cfg(unix)]
+    {
+        struct FdGuard {
+            saved_stdout: libc::c_int,
+            saved_stderr: libc::c_int,
+        }
+
+        impl Drop for FdGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    if self.saved_stdout >= 0 {
+                        libc::dup2(self.saved_stdout, libc::STDOUT_FILENO);
+                        libc::close(self.saved_stdout);
+                    }
+                    if self.saved_stderr >= 0 {
+                        libc::dup2(self.saved_stderr, libc::STDERR_FILENO);
+                        libc::close(self.saved_stderr);
+                    }
+                }
+            }
+        }
+
+        let saved_stdout = unsafe { libc::dup(libc::STDOUT_FILENO) };
+        let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+
+        let _guard = FdGuard {
+            saved_stdout,
+            saved_stderr,
+        };
+
+        if saved_stdout < 0 || saved_stderr < 0 {
+            // Could not save fds — just run without suppression.
+            return f();
+        }
+
+        // Open /dev/null for suppression
+        let devnull_fd = unsafe {
+            libc::open(
+                b"/dev/null\0".as_ptr() as *const libc::c_char,
+                libc::O_WRONLY,
+            )
+        };
+        if devnull_fd >= 0 {
+            unsafe {
+                libc::dup2(devnull_fd, libc::STDOUT_FILENO);
+                libc::dup2(devnull_fd, libc::STDERR_FILENO);
+                libc::close(devnull_fd);
+            }
+        }
+
+        f()
+    }
+
+    #[cfg(not(unix))]
+    {
+        f()
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -106,7 +106,7 @@ where
         // Open /dev/null for suppression
         let devnull_fd = unsafe {
             libc::open(
-                b"/dev/null\0".as_ptr() as *const libc::c_char,
+                c"/dev/null".as_ptr(),
                 libc::O_WRONLY,
             )
         };

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -20,7 +20,12 @@ pub fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
     }
     #[cfg(windows)]
     {
-        std::os::windows::fs::symlink_file(original, link)
+        let orig = original.as_ref();
+        if orig.is_dir() {
+            std::os::windows::fs::symlink_dir(orig, link)
+        } else {
+            std::os::windows::fs::symlink_file(orig, link)
+        }
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -183,7 +183,7 @@ pub struct ServerState {
     pub docs_root: std::path::PathBuf,
     pub token: Option<String>,
     /// Shared embedding service — initialised once at startup, reused per request.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     pub embedding_service: Option<Arc<crate::embedding::EmbeddingService>>,
     /// Per-endpoint rate limiter for search routes (sliding window).
     pub search_rate_limiter: RateLimiter,
@@ -508,11 +508,11 @@ async fn handle_search(
     let project_filter_owned = req.project.clone();
     let q = req.q.clone();
     let limit = req.limit.clamp(1, 200);
-    #[cfg_attr(not(feature = "alcove-full"), allow(unused_variables))]
-    let use_hybrid = req.mode == "hybrid" || (req.mode == "auto" && cfg!(feature = "alcove-full"));
+    #[cfg_attr(not(feature = "embed-candle"), allow(unused_variables))]
+    let use_hybrid = req.mode == "hybrid" || (req.mode == "auto" && cfg!(feature = "embed-candle"));
 
     // Try hybrid search first if available
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     if use_hybrid
         && let Some(service_arc) = state.embedding_service.clone()
         && crate::index::index_exists(&docs_root)
@@ -727,7 +727,7 @@ pub async fn run_server(
         }
     }
 
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     let embedding_service = {
         use crate::config::load_config;
         use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
@@ -763,7 +763,7 @@ pub async fn run_server(
     let state = Arc::new(ServerState {
         docs_root,
         token,
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "embed-candle")]
         embedding_service,
         search_rate_limiter: RateLimiter::new(60, std::time::Duration::from_secs(60)),
     });
@@ -913,7 +913,7 @@ mod tests {
         Arc::new(ServerState {
             docs_root,
             token: None,
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding_service: None,
             search_rate_limiter: super::RateLimiter::new(1000, std::time::Duration::from_secs(60)),
         })
@@ -1072,7 +1072,7 @@ mod tests {
         let state = Arc::new(ServerState {
             docs_root: std::path::PathBuf::from("/tmp"),
             token: None,
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding_service: None,
             search_rate_limiter: super::RateLimiter::new(1000, std::time::Duration::from_secs(60)),
         });
@@ -1085,7 +1085,7 @@ mod tests {
         let state = Arc::new(ServerState {
             docs_root: std::path::PathBuf::from("/tmp"),
             token: Some("my-secret".to_string()),
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding_service: None,
             search_rate_limiter: super::RateLimiter::new(1000, std::time::Duration::from_secs(60)),
         });
@@ -1098,7 +1098,7 @@ mod tests {
         let state = Arc::new(ServerState {
             docs_root: std::path::PathBuf::from("/tmp"),
             token: Some("my-secret".to_string()),
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding_service: None,
             search_rate_limiter: super::RateLimiter::new(1000, std::time::Duration::from_secs(60)),
         });
@@ -1193,7 +1193,7 @@ mod tests {
         let state = Arc::new(ServerState {
             docs_root: std::path::PathBuf::from("/tmp"),
             token: Some("my-secret".to_string()),
-            #[cfg(feature = "alcove-full")]
+            #[cfg(feature = "embed-candle")]
             embedding_service: None,
             search_rate_limiter: super::RateLimiter::new(1000, std::time::Duration::from_secs(60)),
         });

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -280,7 +280,7 @@ fn print_step_header(step: &Step) {
 // ---------------------------------------------------------------------------
 
 /// Embedding model options for setup wizard
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "embed-candle")]
 const EMBEDDING_OPTIONS: &[(&str, &str, usize, usize)] = &[
     (
         "MultilingualE5Small",
@@ -533,7 +533,7 @@ fn step_diagram(state: &mut SetupState) -> Result<StepResult> {
 fn step_embedding(state: &mut SetupState) -> Result<StepResult> {
     print_step_header(&Step::Embedding);
 
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     {
         // Check current config
         let current_model = state
@@ -659,7 +659,7 @@ fn step_embedding(state: &mut SetupState) -> Result<StepResult> {
         }
     }
 
-    #[cfg(not(feature = "alcove-full"))]
+    #[cfg(not(feature = "embed-candle"))]
     {
         // Add back option for non-full feature
         let labels = vec![
@@ -684,7 +684,7 @@ fn step_embedding(state: &mut SetupState) -> Result<StepResult> {
         println!();
         println!("  To enable hybrid search later, reinstall with:");
         println!(
-            "  {} cargo install alcove --features alcove-full",
+            "  {} cargo install alcove --features embed-candle",
             style("→").cyan()
         );
         println!();
@@ -1207,7 +1207,7 @@ fn step_summary(state: &mut SetupState) -> Result<StepResult> {
                 .lines()
                 .find_map(|l| l.strip_prefix("model = ").map(|v| v.trim_matches('"')));
             if let Some(model_name) = model {
-                #[cfg(feature = "alcove-full")]
+                #[cfg(feature = "embed-candle")]
                 {
                     let m = crate::embedding::EmbeddingModelChoice::parse(model_name);
                     println!(
@@ -1217,7 +1217,7 @@ fn step_summary(state: &mut SetupState) -> Result<StepResult> {
                         m.map(|m| m.size_mb()).unwrap_or(235)
                     );
                 }
-                #[cfg(not(feature = "alcove-full"))]
+                #[cfg(not(feature = "embed-candle"))]
                 {
                     println!("  Embedding: {} (configured)", model_name);
                 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -353,7 +353,7 @@ pub fn tool_search(
     let docs_root = project_root.parent().unwrap_or(project_root);
 
     // Try indexed search first (faster and ranked)
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "embed-candle")]
     {
         use crate::config::load_config;
         use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
@@ -2845,7 +2845,7 @@ mod tests {
 
         // Create a symlink inside the project root pointing outside
         let link = project_root.join("escape.md");
-        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        crate::platform::create_symlink(&outside, &link).unwrap();
 
         let args = json!({"relative_path": "escape.md"});
         let result = tool_get_file(&project_root, args);

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -97,11 +97,7 @@ pub fn link_vault(name: &str, target: &Path) -> Result<PathBuf> {
     }
     // Ensure parent directory exists
     fs::create_dir_all(vaults_root()).with_context(|| "Failed to create vaults root directory")?;
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(target, &link_path)
-        .with_context(|| format!("Failed to create symlink: {}", link_path.display()))?;
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(target, &link_path)
+    crate::platform::create_symlink(target, &link_path)
         .with_context(|| format!("Failed to create symlink: {}", link_path.display()))?;
     Ok(link_path)
 }
@@ -306,10 +302,7 @@ mod tests {
         if link_path.exists() || link_path.symlink_metadata().is_ok() {
             anyhow::bail!("Vault '{}' already exists", name);
         }
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(target, &link_path)?;
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(target, &link_path)?;
+        crate::platform::create_symlink(target, &link_path)?;
         Ok(link_path)
     }
 
@@ -382,14 +375,13 @@ mod tests {
         fs::create_dir_all(&ext).unwrap();
         fs::write(ext.join("x.md"), "# X").unwrap();
         #[cfg(unix)]
-        std::os::unix::fs::symlink(&ext, vaults.join("linked")).unwrap();
+        crate::platform::create_symlink(&ext, vaults.join("linked")).unwrap();
 
         let list = list_vaults_in(&vaults).unwrap();
 
         let real = list.iter().find(|v| v.name == "docs").unwrap();
         assert!(!real.is_link);
         assert_eq!(real.doc_count, 2);
-
         #[cfg(unix)]
         {
             let linked = list.iter().find(|v| v.name == "linked").unwrap();
@@ -423,7 +415,7 @@ mod tests {
         fs::write(target.join("keep.md"), "# Keep").unwrap();
 
         #[cfg(unix)]
-        std::os::unix::fs::symlink(&target, vaults.join("linked")).unwrap();
+        crate::platform::create_symlink(&target, vaults.join("linked")).unwrap();
         #[cfg(unix)]
         {
             remove_vault_in(&vaults, "linked").unwrap();

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,21 +1,21 @@
-//! Vector store using SQLite for persistence (alcove-full feature)
+//! Vector store using SQLite for persistence (vector feature)
 //!
 //! Stores document chunk embeddings as BLOBs and computes cosine similarity in Rust.
 //! This avoids complex FFI dependencies while providing efficient vector search.
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 use std::cmp::Ordering;
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 use std::collections::BinaryHeap;
 use std::path::Path;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 use anyhow::Result;
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 use rusqlite::{Connection, params};
 
 /// Vector store metadata
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct VectorMeta {
@@ -28,7 +28,7 @@ pub struct VectorMeta {
 }
 
 /// Search result with similarity score
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorResult {
     /// Project name
@@ -46,24 +46,24 @@ pub struct VectorResult {
 /// `BinaryHeap` is a max-heap by default; reversing `Ord` makes it a min-heap
 /// so the *lowest* score sits at the top and can be cheaply evicted once the
 /// heap exceeds the desired limit.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 #[derive(PartialEq)]
 struct MinScoreEntry {
     score: f32,
     result: VectorResult,
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 impl Eq for MinScoreEntry {}
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 impl PartialOrd for MinScoreEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 impl Ord for MinScoreEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reversed: smallest score at the top (min-heap)
@@ -82,7 +82,7 @@ impl Ord for MinScoreEntry {
 ///
 /// `key = None`       → index built from ALL projects
 /// `key = Some(name)` → index built from that project only
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 struct HnswCacheEntry {
     index: hnsw_rs::prelude::Hnsw<'static, f32, hnsw_rs::prelude::DistCosine>,
     /// Maps HNSW d_id (= SQLite row `id` as usize) → (project, file, chunk_id)
@@ -95,10 +95,10 @@ struct HnswCacheEntry {
 /// When exceeded, the least-recently-used entry is evicted before inserting a new one.
 /// Reduced from 8 → 3 to bound peak memory; each entry can consume 50–300 MB
 /// depending on vector count and dimension.
-#[cfg(all(feature = "alcove-full", not(test)))]
+#[cfg(all(feature = "vector", not(test)))]
 const HNSW_CACHE_MAX_ENTRIES: usize = 3;
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 pub struct VectorStore {
     conn: Connection,
     dimension: usize,
@@ -123,7 +123,7 @@ pub struct VectorStore {
 // TTL eviction helper (module-private)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 fn evict_stale(cache: &mut std::collections::HashMap<Option<String>, HnswCacheEntry>) {
     let ttl = std::time::Duration::from_secs(300); // 5 minutes
     cache.retain(|_, entry| entry.last_accessed.elapsed() < ttl);
@@ -133,7 +133,7 @@ fn evict_stale(cache: &mut std::collections::HashMap<Option<String>, HnswCacheEn
 // VectorStore impl
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 impl VectorStore {
     /// Open or create a vector store at the given path
     pub fn open(path: &Path, model: &str, dimension: usize) -> Result<Self> {
@@ -339,7 +339,7 @@ impl VectorStore {
         };
 
         // Use HNSW for large datasets (>= 5000 vectors)
-        #[cfg(feature = "alcove-full")]
+        #[cfg(feature = "vector")]
         if count >= 5000 {
             return self.search_hnsw(query, limit, project_filter);
         }
@@ -441,7 +441,7 @@ impl VectorStore {
     ///
     /// The index is scoped to `project_filter` and cached under the matching key.
     /// Stale entries (TTL = 5 min) are evicted at the start of each call.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     fn search_hnsw(
         &self,
         query: &[f32],
@@ -645,7 +645,7 @@ impl VectorStore {
 // ---------------------------------------------------------------------------
 
 /// Compute cosine similarity between two vectors
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
@@ -667,7 +667,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// RRF score = bm25_weight / (k + rank_bm25) + vector_weight / (k + rank_vector)
 /// Default k = 60 (commonly used value). BM25 is weighted at 0.6 and vector at 0.4
 /// to give slight preference to the lexical signal.
-#[cfg(feature = "alcove-full")]
+#[cfg(feature = "vector")]
 pub fn reciprocal_rank_fusion(
     bm25_results: &[(String, String, u64, f32)], // (project, file, chunk_id, score)
     vector_results: &[VectorResult],
@@ -742,7 +742,7 @@ mod tests {
     }
 
     /// Fix 1: reopening with a different model must clear all vectors atomically.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     #[test]
     fn test_open_model_change_clears_vectors() {
         let dir = tempfile::tempdir().unwrap();
@@ -769,7 +769,7 @@ mod tests {
     }
 
     /// Fix 2: search_linear with project_filter must only return matching project rows.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     #[test]
     fn test_search_linear_project_filter() {
         let dir = tempfile::tempdir().unwrap();
@@ -798,7 +798,7 @@ mod tests {
 
     /// Cache: second search reuses the HNSW index without rebuilding it.
     /// Uses `contains_key` checks on the per-project HashMap.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     #[test]
     #[ignore = "stress test: builds 5000-vector HNSW graph, run explicitly with -- --ignored"]
     fn test_hnsw_cache_reused_on_second_search() {
@@ -887,7 +887,7 @@ mod tests {
     /// not the global None key or the proj-b key.
     /// Ignored in normal test runs because the HNSW cache is bypassed in test
     /// builds. Run with `cargo test -- --ignored` to verify cache behaviour.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     #[test]
     #[ignore = "HNSW cache is bypassed in test builds; run with --ignored to verify"]
     fn test_hnsw_cache_per_project() {
@@ -936,7 +936,7 @@ mod tests {
     /// TTL eviction: a manually backdated entry must be evicted on next search.
     /// Ignored in normal test runs because the HNSW cache is bypassed in test
     /// builds. Run with `cargo test -- --ignored` to verify cache behaviour.
-    #[cfg(feature = "alcove-full")]
+    #[cfg(feature = "vector")]
     #[test]
     #[ignore = "HNSW cache is bypassed in test builds; run with --ignored to verify"]
     fn test_hnsw_cache_ttl_eviction() {


### PR DESCRIPTION
## Summary

Replace fastembed/ort-sys (ONNX Runtime) with candle-transformers to enable builds on macOS (ARM + Intel), Linux (x86_64 + ARM64), and Windows.

## Spec

Implements `SPEC-20260513-cross-platform-candle` — all 10 requirements (R1-R10), 9 acceptance criteria (AC1-AC9).

## Changes

### R1: candle-transformers embedding backend
- Replaced fastembed ONNX with candle BERT inference
- Downloads model weights from HuggingFace Hub (safetensors + mmap)
- Mean pooling + L2 normalization (matches Python sentence-transformers output)
- Default model: `all-MiniLM-L6-v2` (80MB, 384d)

### R2: EmbeddingProvider abstraction
- `CandleSession` encapsulates BertModel + Tokenizer
- `EmbeddingService` public API unchanged — zero breaking changes for callers

### R3: Platform abstraction (`src/platform.rs`)
- `create_symlink()` — Unix/Windows symlink abstraction
- `is_pid_alive()` — Unix kill-0 / Windows conservative fallback
- `send_terminate()` — Unix SIGTERM / Windows no-op
- `suppress_fds()` — Unix fd dup/restore / Windows no-op

### R4: rusqlite bundled
- `features = ["bundled"]` — no system SQLite required

### R5: Unix-only code paths fixed
- All `libc::` and `std::os::unix` calls moved to `platform.rs`
- vault.rs, commands.rs, index/lock.rs, index/reader.rs, tools.rs updated

### R6: Feature matrix redesign
```
default = ["core"]
core = ["rusqlite", "alcove-server"]
embed-candle = ["candle-transformers", "candle-nn", "candle-core", "hf-hub", "tokenizers"]
vector = ["hnsw_rs"]
pdf = ["pdf-extract"]          # Unix-only
office = ["zip", "quick-xml", "calamine"]
full-macos  = [core + embed-candle + vector + pdf + office + server]
full-cross  = [core + embed-candle + vector + office + server]  # no pdf
```

### R7: dist-workspace.toml — 5 targets
| Target | Features |
|--------|----------|
| aarch64-apple-darwin | full-macos |
| x86_64-apple-darwin | full-cross |
| x86_64-unknown-linux-gnu | full-cross |
| aarch64-unknown-linux-gnu | full-cross |
| x86_64-pc-windows-msvc | full-cross |

### R8: CI matrix expanded
- `check`: full-macos on ubuntu-latest
- `cross-check`: matrix for Linux x86, Linux ARM64, Windows
- `macos-intel-check`: x86_64-apple-darwin on macos-13
- `test`: full-macos on macos-latest

### R10: Zero breaking changes
- Existing macOS ARM users: `full` → `full-macos` (backward compat alias)
- `EmbeddingService` public API unchanged
- BM25-only fallback still works when models are not available

## Test plan
- [x] `cargo check --features full-macos` — clean
- [x] `cargo check --features full-cross` — clean
- [x] `cargo check --features core` — clean
- [ ] CI cross-platform checks pass
- [ ] `cargo test --features full-macos` passes
- [ ] Vector search quality equivalent (manual verification)