### PR TITLE
feat(embed): XLM-RoBERTa support for BGE-M3, pytorch fallback, env var override

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Skills are available immediately — no further steps needed.
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 Skills are available immediately — no further steps needed.

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -130,7 +130,7 @@ Skills sind sofort verfügbar — keine weiteren Schritte erforderlich.
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 Skills sind sofort verfügbar — keine weiteren Schritte erforderlich.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -130,7 +130,7 @@ Las skills están disponibles inmediatamente — no se necesitan más pasos.
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 Las skills están disponibles inmediatamente — no se necesitan más pasos.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -130,7 +130,7 @@ Les skills sont disponibles immédiatement — aucune étape supplémentaire né
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 Les skills sont disponibles immédiatement — aucune étape supplémentaire nécessaire.

--- a/docs/README.hi.md
+++ b/docs/README.hi.md
@@ -130,7 +130,7 @@ codex plugin marketplace add epicsagas/plugins
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 स्किल्स तुरंत उपलब्ध हैं — कोई अतिरिक्त कदम आवश्यक नहीं।

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -130,7 +130,7 @@ codex plugin marketplace add epicsagas/plugins
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 スキルはすぐに利用可能です — 追加手順は不要です。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -130,7 +130,7 @@ codex plugin marketplace add epicsagas/plugins
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 스킬은 즉시 사용 가능합니다 — 추가 단계 불필요.

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -130,7 +130,7 @@ As skills estão disponíveis imediatamente — nenhum passo adicional necessár
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 As skills estão disponíveis imediatamente — nenhum passo adicional necessário.

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -130,7 +130,7 @@ codex plugin marketplace add epicsagas/plugins
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 Навыки доступны сразу — дополнительные шаги не требуются.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -130,7 +130,7 @@ codex plugin marketplace add epicsagas/plugins
 ### Antigravity
 
 ```bash
-antigravity plugin marketplace add epicsagas/plugins
+agy marketplace add epicsagas/plugins
 ```
 
 技能立即可用 — 无需额外步骤。

--- a/src/config.rs
+++ b/src/config.rs
@@ -399,9 +399,8 @@ impl DocConfig {
             embedding: self.embedding.clone().or_else(|| base.embedding.clone()),
             server: self.server.clone().or_else(|| base.server.clone()),
             memory: self.memory.clone().or_else(|| base.memory.clone()),
-            // vector_index: project-level value wins; false does not inherit base
-            // (a project's explicit false should not be overridden by base true)
-            vector_index: self.vector_index,
+            // vector_index: project true wins; otherwise inherit from base
+            vector_index: if self.vector_index { true } else { base.vector_index },
         }
     }
 
@@ -501,8 +500,18 @@ impl DocConfig {
         &self.embedding
     }
 
-    /// Get embedding configuration with defaults applied
+    /// Get embedding configuration with defaults applied.
+    /// `ALCOVE_EMBEDDING_MODEL` env var overrides the configured model name.
     #[cfg(feature = "embed-candle")]
+    pub fn embedding_config_with_defaults(&self) -> EmbeddingConfig {
+        let mut cfg = self.embedding.clone().unwrap_or_default();
+        if let Ok(model) = std::env::var("ALCOVE_EMBEDDING_MODEL") {
+            cfg.model = model;
+        }
+        cfg
+    }
+
+    #[cfg(not(feature = "embed-candle"))]
     pub fn embedding_config_with_defaults(&self) -> EmbeddingConfig {
         self.embedding.clone().unwrap_or_default()
     }
@@ -1509,9 +1518,9 @@ reader_ttl_secs = 120
     }
 
     #[test]
-    fn vector_index_overlay_project_false_not_overridden_by_base_true() {
-        // A project that explicitly sets vector_index = false should not inherit
-        // a hypothetical base value of true.
+    fn vector_index_overlay_project_default_inherits_base_true() {
+        // A project without vector_index set (default false) should inherit
+        // the base (global) value of true.
         let base = DocConfig {
             vector_index: true,
             ..DocConfig::default()
@@ -1521,7 +1530,7 @@ reader_ttl_secs = 120
             ..DocConfig::default()
         };
         let merged = project.overlay(&base);
-        assert!(!merged.vector_index);
+        assert!(merged.vector_index);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -400,7 +400,11 @@ impl DocConfig {
             server: self.server.clone().or_else(|| base.server.clone()),
             memory: self.memory.clone().or_else(|| base.memory.clone()),
             // vector_index: project true wins; otherwise inherit from base
-            vector_index: if self.vector_index { true } else { base.vector_index },
+            vector_index: if self.vector_index {
+                true
+            } else {
+                base.vector_index
+            },
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -510,11 +510,6 @@ impl DocConfig {
         cfg
     }
 
-    #[cfg(not(feature = "embed-candle"))]
-    pub fn embedding_config_with_defaults(&self) -> EmbeddingConfig {
-        self.embedding.clone().unwrap_or_default()
-    }
-
     /// Get resolved server configuration (config value with defaults applied).
     #[cfg(feature = "alcove-server")]
     pub fn server_config(&self) -> ServerConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,10 +374,10 @@ pub struct DocConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<MemoryConfig>,
     /// Opt-in flag to enable vector embedding for this project.
-    /// Default: `false` — vector indexing is skipped unless explicitly enabled.
-    /// Set `vector_index = true` in `alcove.toml` to enable.
+    /// `None` (absent from TOML) inherits from the global config during overlay.
+    /// `Some(true)` enables vector indexing; `Some(false)` explicitly disables it.
     #[serde(default)]
-    pub vector_index: bool,
+    pub vector_index: Option<bool>,
 }
 
 impl DocConfig {
@@ -399,12 +399,7 @@ impl DocConfig {
             embedding: self.embedding.clone().or_else(|| base.embedding.clone()),
             server: self.server.clone().or_else(|| base.server.clone()),
             memory: self.memory.clone().or_else(|| base.memory.clone()),
-            // vector_index: project true wins; otherwise inherit from base
-            vector_index: if self.vector_index {
-                true
-            } else {
-                base.vector_index
-            },
+            vector_index: self.vector_index.or(base.vector_index),
         }
     }
 
@@ -585,7 +580,7 @@ pub fn load_config() -> &'static DocConfig {
             embedding: None,
             server: None,
             memory: None,
-            vector_index: false,
+            vector_index: None,
         }
     })
 }
@@ -1480,61 +1475,75 @@ reader_ttl_secs = 120
     // -- vector_index opt-in flag --
 
     #[test]
-    fn vector_index_default_is_false() {
+    fn vector_index_default_is_none() {
         let cfg = DocConfig::default();
-        assert!(!cfg.vector_index, "vector_index must default to false");
+        assert_eq!(cfg.vector_index, None, "vector_index must default to None");
     }
 
     #[test]
     fn vector_index_toml_true() {
         let toml = r#"vector_index = true"#;
         let cfg: DocConfig = toml::from_str(toml).unwrap();
-        assert!(cfg.vector_index);
+        assert_eq!(cfg.vector_index, Some(true));
     }
 
     #[test]
     fn vector_index_toml_false() {
         let toml = r#"vector_index = false"#;
         let cfg: DocConfig = toml::from_str(toml).unwrap();
-        assert!(!cfg.vector_index);
+        assert_eq!(cfg.vector_index, Some(false));
     }
 
     #[test]
-    fn vector_index_toml_absent_defaults_to_false() {
-        // An alcove.toml with no vector_index key should parse to false.
+    fn vector_index_toml_absent_defaults_to_none() {
         let toml = r#"docs_root = "/tmp/docs""#;
         let cfg: DocConfig = toml::from_str(toml).unwrap();
-        assert!(!cfg.vector_index);
+        assert_eq!(cfg.vector_index, None);
     }
 
     #[test]
     fn vector_index_overlay_project_true_wins() {
         let base = DocConfig {
-            vector_index: false,
+            vector_index: Some(false),
             ..DocConfig::default()
         };
         let project = DocConfig {
-            vector_index: true,
+            vector_index: Some(true),
             ..DocConfig::default()
         };
         let merged = project.overlay(&base);
-        assert!(merged.vector_index);
+        assert_eq!(merged.vector_index, Some(true));
     }
 
     #[test]
-    fn vector_index_overlay_project_default_inherits_base_true() {
-        // A project without vector_index set (default false) should inherit
-        // the base (global) value of true.
+    fn vector_index_overlay_project_false_overrides_base_true() {
+        // A project that explicitly sets vector_index = false should NOT
+        // inherit the base (global) value of true.
         let base = DocConfig {
-            vector_index: true,
+            vector_index: Some(true),
             ..DocConfig::default()
         };
         let project = DocConfig {
-            vector_index: false,
+            vector_index: Some(false),
             ..DocConfig::default()
         };
         let merged = project.overlay(&base);
-        assert!(merged.vector_index);
+        assert_eq!(merged.vector_index, Some(false));
+    }
+
+    #[test]
+    fn vector_index_overlay_project_none_inherits_base_true() {
+        // A project without vector_index set (None) should inherit from base.
+        let base = DocConfig {
+            vector_index: Some(true),
+            ..DocConfig::default()
+        };
+        let project = DocConfig {
+            vector_index: None,
+            ..DocConfig::default()
+        };
+        let merged = project.overlay(&base);
+        assert_eq!(merged.vector_index, Some(true));
     }
 
     #[test]
@@ -1542,11 +1551,11 @@ reader_ttl_secs = 120
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("alcove.toml"), "vector_index = true\n").unwrap();
         let cfg = load_project_config(tmp.path());
-        assert!(cfg.vector_index);
+        assert_eq!(cfg.vector_index, Some(true));
     }
 
     #[test]
-    fn load_project_config_vector_index_absent_is_false() {
+    fn load_project_config_vector_index_absent_is_none() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(
             tmp.path().join("alcove.toml"),
@@ -1554,6 +1563,6 @@ reader_ttl_secs = 120
         )
         .unwrap();
         let cfg = load_project_config(tmp.path());
-        assert!(!cfg.vector_index);
+        assert_eq!(cfg.vector_index, None);
     }
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -722,6 +722,7 @@ mod tests {
             assert_eq!(EmbeddingModelChoice::MultilingualE5Small.dimension(), 384);
             assert_eq!(EmbeddingModelChoice::MultilingualE5Base.dimension(), 768);
             assert_eq!(EmbeddingModelChoice::MultilingualE5Large.dimension(), 1024);
+            assert_eq!(EmbeddingModelChoice::BGEM3.dimension(), 1024);
         }
     }
 
@@ -754,6 +755,10 @@ mod tests {
                 EmbeddingModelChoice::parse("AllMiniLML6V2"),
                 Some(EmbeddingModelChoice::AllMiniLML6V2)
             );
+            assert_eq!(
+                EmbeddingModelChoice::parse("BGEM3"),
+                Some(EmbeddingModelChoice::BGEM3)
+            );
             assert_eq!(EmbeddingModelChoice::parse("InvalidModel"), None);
         }
     }
@@ -777,6 +782,16 @@ mod tests {
         {
             assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.size_mb(), 80);
             assert_eq!(EmbeddingModelChoice::BGEM3.size_mb(), 2300);
+        }
+    }
+
+    #[test]
+    fn test_is_xlm_roberta() {
+        #[cfg(feature = "embed-candle")]
+        {
+            assert!(EmbeddingModelChoice::BGEM3.is_xlm_roberta());
+            assert!(!EmbeddingModelChoice::AllMiniLML6V2.is_xlm_roberta());
+            assert!(!EmbeddingModelChoice::MultilingualE5Large.is_xlm_roberta());
         }
     }
 

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -257,13 +257,18 @@ impl CandleSession {
             ..Default::default()
         }));
 
-        // Try single-shard first, then fall back to multi-shard via index.json
-        let vb = match api_repo.get("model.safetensors") {
-            Ok(path) => unsafe { VarBuilder::from_mmaped_safetensors(&[path], DTYPE, &device)? },
-            Err(_) => {
-                let index_path = api_repo.get("model.safetensors.index.json").context(
-                    "Failed to download model.safetensors or model.safetensors.index.json",
-                )?;
+        // Weight loading: safetensors (single → multi-shard) → pytorch fallback
+        let vb = 'vb: {
+            // 1. Single-shard safetensors
+            if let Ok(path) = api_repo.get("model.safetensors") {
+                // SAFETY: mmaped safetensors files are read-only and the file content
+                // is not modified after loading. The HuggingFace Hub cache guarantees
+                // atomic file placement (write-to-temp + rename).
+                break 'vb unsafe { VarBuilder::from_mmaped_safetensors(&[path], DTYPE, &device)? };
+            }
+
+            // 2. Multi-shard safetensors via index.json
+            if let Ok(index_path) = api_repo.get("model.safetensors.index.json") {
                 let index_str = std::fs::read_to_string(&index_path)
                     .context("Failed to read model.safetensors.index.json")?;
                 let shard_map: serde_json::Value = serde_json::from_str(&index_str)
@@ -296,8 +301,22 @@ impl CandleSession {
                     !shard_paths.is_empty(),
                     "No safetensor shards found in index"
                 );
-                unsafe { VarBuilder::from_mmaped_safetensors(&shard_paths, DTYPE, &device)? }
+                // SAFETY: same rationale as single-shard — read-only mmaped safetensors.
+                break 'vb unsafe {
+                    VarBuilder::from_mmaped_safetensors(&shard_paths, DTYPE, &device)?
+                };
             }
+
+            // 3. PyTorch fallback (e.g. BGE-M3 ships as pytorch_model.bin)
+            if let Ok(path) = api_repo.get("pytorch_model.bin") {
+                break 'vb VarBuilder::from_pth(&path, DTYPE, &device)
+                    .context("Failed to load pytorch_model.bin")?;
+            }
+
+            anyhow::bail!(
+                "No model weights found (tried model.safetensors, \
+                 model.safetensors.index.json, pytorch_model.bin)"
+            );
         };
 
         let session = if model_choice.is_xlm_roberta() {
@@ -320,62 +339,23 @@ impl CandleSession {
     fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         let device = candle_core::Device::Cpu;
 
-        let (encodings, embeddings) = match &self.session {
-            ModelSession::Bert { model, tokenizer } => {
-                let encodings = tokenizer
-                    .encode_batch(texts.to_vec(), true)
-                    .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
-                let token_ids = Tensor::stack(
-                    &encodings
-                        .iter()
-                        .map(|e| Tensor::new(e.get_ids(), &device))
-                        .collect::<candle_core::Result<Vec<_>>>()?,
-                    0,
-                )?;
-                let attention_mask = Tensor::stack(
-                    &encodings
-                        .iter()
-                        .map(|e| Tensor::new(e.get_attention_mask(), &device))
-                        .collect::<candle_core::Result<Vec<_>>>()?,
-                    0,
-                )?;
-                let token_type_ids = token_ids.zeros_like()?;
-                let embeddings =
-                    model.forward(&token_ids, &token_type_ids, Some(&attention_mask))?;
-                (encodings, embeddings)
-            }
-            ModelSession::XlmRoberta { model, tokenizer } => {
-                let encodings = tokenizer
-                    .encode_batch(texts.to_vec(), true)
-                    .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
-                let token_ids = Tensor::stack(
-                    &encodings
-                        .iter()
-                        .map(|e| Tensor::new(e.get_ids(), &device))
-                        .collect::<candle_core::Result<Vec<_>>>()?,
-                    0,
-                )?;
-                let attention_mask = Tensor::stack(
-                    &encodings
-                        .iter()
-                        .map(|e| Tensor::new(e.get_attention_mask(), &device))
-                        .collect::<candle_core::Result<Vec<_>>>()?,
-                    0,
-                )?;
-                let token_type_ids = token_ids.zeros_like()?;
-                let embeddings = model.forward(
-                    &token_ids,
-                    &attention_mask,
-                    &token_type_ids,
-                    None,
-                    None,
-                    None,
-                )?;
-                (encodings, embeddings)
+        // Tokenize — all architectures share the same tokenizer interface
+        let tokenizer = match &self.session {
+            ModelSession::Bert { tokenizer, .. } | ModelSession::XlmRoberta { tokenizer, .. } => {
+                tokenizer
             }
         };
+        let encodings = tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
 
-        // Mean pooling with attention mask
+        let token_ids = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|e| Tensor::new(e.get_ids(), &device))
+                .collect::<candle_core::Result<Vec<_>>>()?,
+            0,
+        )?;
         let attention_mask = Tensor::stack(
             &encodings
                 .iter()
@@ -383,6 +363,24 @@ impl CandleSession {
                 .collect::<candle_core::Result<Vec<_>>>()?,
             0,
         )?;
+        let token_type_ids = token_ids.zeros_like()?;
+
+        // Forward pass — only the model call differs between architectures
+        let embeddings = match &self.session {
+            ModelSession::Bert { model, .. } => {
+                model.forward(&token_ids, &token_type_ids, Some(&attention_mask))?
+            }
+            ModelSession::XlmRoberta { model, .. } => model.forward(
+                &token_ids,
+                &attention_mask,
+                &token_type_ids,
+                None,
+                None,
+                None,
+            )?,
+        };
+
+        // Mean pooling with attention mask
         let mask_f = attention_mask.to_dtype(DTYPE)?.unsqueeze(2)?;
         let sum_mask = mask_f.sum(1)?;
         let pooled = (embeddings.broadcast_mul(&mask_f)?)

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -211,8 +211,14 @@ impl QueryEmbedCache {
 /// Holds a loaded model + tokenizer, ready for inference.
 #[cfg(feature = "embed-candle")]
 enum ModelSession {
-    Bert { model: BertModel, tokenizer: tokenizers::Tokenizer },
-    XlmRoberta { model: XLMRobertaModel, tokenizer: tokenizers::Tokenizer },
+    Bert {
+        model: BertModel,
+        tokenizer: tokenizers::Tokenizer,
+    },
+    XlmRoberta {
+        model: XLMRobertaModel,
+        tokenizer: tokenizers::Tokenizer,
+    },
 }
 
 #[cfg(feature = "embed-candle")]
@@ -295,8 +301,8 @@ impl CandleSession {
         };
 
         let session = if model_choice.is_xlm_roberta() {
-            let config: XlmRobertaConfig =
-                serde_json::from_str(&config_str).context("Failed to parse XLM-RoBERTa config.json")?;
+            let config: XlmRobertaConfig = serde_json::from_str(&config_str)
+                .context("Failed to parse XLM-RoBERTa config.json")?;
             let model = XLMRobertaModel::new(&config, vb.pp("roberta"))
                 .context("Failed to load XLM-RoBERTa model")?;
             ModelSession::XlmRoberta { model, tokenizer }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -374,9 +374,9 @@ impl CandleSession {
                 &token_ids,
                 &attention_mask,
                 &token_type_ids,
-                None,
-                None,
-                None,
+                None, // past_key_value
+                None, // encoder_hidden_states
+                None, // encoder_attention_mask
             )?,
         };
 

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -18,7 +18,9 @@ use candle_core::Tensor;
 #[cfg(feature = "embed-candle")]
 use candle_nn::VarBuilder;
 #[cfg(feature = "embed-candle")]
-use candle_transformers::models::bert::{BertModel, Config, DTYPE};
+use candle_transformers::models::bert::{BertModel, Config as BertConfig, DTYPE};
+#[cfg(feature = "embed-candle")]
+use candle_transformers::models::xlm_roberta::{Config as XlmRobertaConfig, XLMRobertaModel};
 #[cfg(feature = "embed-candle")]
 use hf_hub::api::sync::ApiBuilder;
 #[cfg(feature = "embed-candle")]
@@ -146,6 +148,10 @@ impl EmbeddingModelChoice {
             _ => None,
         }
     }
+
+    pub fn is_xlm_roberta(self) -> bool {
+        matches!(self, Self::BGEM3)
+    }
 }
 
 impl std::fmt::Display for EmbeddingModelChoice {
@@ -202,16 +208,21 @@ impl QueryEmbedCache {
 // Candle-based embedding session (the actual inference engine)
 // ---------------------------------------------------------------------------
 
-/// Holds a loaded candle BERT model + tokenizer, ready for inference.
+/// Holds a loaded model + tokenizer, ready for inference.
+#[cfg(feature = "embed-candle")]
+enum ModelSession {
+    Bert { model: BertModel, tokenizer: tokenizers::Tokenizer },
+    XlmRoberta { model: XLMRobertaModel, tokenizer: tokenizers::Tokenizer },
+}
+
 #[cfg(feature = "embed-candle")]
 struct CandleSession {
-    model: BertModel,
-    tokenizer: tokenizers::Tokenizer,
+    session: ModelSession,
 }
 
 #[cfg(feature = "embed-candle")]
 impl CandleSession {
-    /// Download model files from HuggingFace Hub and build a BERT session.
+    /// Download model files from HuggingFace Hub and build a session.
     fn load(model_choice: EmbeddingModelChoice, cache_dir: &std::path::Path) -> Result<Self> {
         let device = candle_core::Device::Cpu;
         let model_id = model_choice.model_id();
@@ -232,8 +243,6 @@ impl CandleSession {
 
         let config_str =
             std::fs::read_to_string(&config_path).context("Failed to read config.json")?;
-        let config: Config =
-            serde_json::from_str(&config_str).context("Failed to parse config.json")?;
 
         let mut tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
@@ -284,27 +293,83 @@ impl CandleSession {
                 unsafe { VarBuilder::from_mmaped_safetensors(&shard_paths, DTYPE, &device)? }
             }
         };
-        let model = BertModel::load(vb, &config)?;
 
-        Ok(Self { model, tokenizer })
+        let session = if model_choice.is_xlm_roberta() {
+            let config: XlmRobertaConfig =
+                serde_json::from_str(&config_str).context("Failed to parse XLM-RoBERTa config.json")?;
+            let model = XLMRobertaModel::new(&config, vb.pp("roberta"))
+                .context("Failed to load XLM-RoBERTa model")?;
+            ModelSession::XlmRoberta { model, tokenizer }
+        } else {
+            let config: BertConfig =
+                serde_json::from_str(&config_str).context("Failed to parse BERT config.json")?;
+            let model = BertModel::load(vb, &config)?;
+            ModelSession::Bert { model, tokenizer }
+        };
+
+        Ok(Self { session })
     }
 
     /// Embed a batch of texts, returning one Vec<f32> per text.
     fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         let device = candle_core::Device::Cpu;
 
-        let encodings = self
-            .tokenizer
-            .encode_batch(texts.to_vec(), true)
-            .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+        let (encodings, embeddings) = match &self.session {
+            ModelSession::Bert { model, tokenizer } => {
+                let encodings = tokenizer
+                    .encode_batch(texts.to_vec(), true)
+                    .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+                let token_ids = Tensor::stack(
+                    &encodings
+                        .iter()
+                        .map(|e| Tensor::new(e.get_ids(), &device))
+                        .collect::<candle_core::Result<Vec<_>>>()?,
+                    0,
+                )?;
+                let attention_mask = Tensor::stack(
+                    &encodings
+                        .iter()
+                        .map(|e| Tensor::new(e.get_attention_mask(), &device))
+                        .collect::<candle_core::Result<Vec<_>>>()?,
+                    0,
+                )?;
+                let token_type_ids = token_ids.zeros_like()?;
+                let embeddings =
+                    model.forward(&token_ids, &token_type_ids, Some(&attention_mask))?;
+                (encodings, embeddings)
+            }
+            ModelSession::XlmRoberta { model, tokenizer } => {
+                let encodings = tokenizer
+                    .encode_batch(texts.to_vec(), true)
+                    .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+                let token_ids = Tensor::stack(
+                    &encodings
+                        .iter()
+                        .map(|e| Tensor::new(e.get_ids(), &device))
+                        .collect::<candle_core::Result<Vec<_>>>()?,
+                    0,
+                )?;
+                let attention_mask = Tensor::stack(
+                    &encodings
+                        .iter()
+                        .map(|e| Tensor::new(e.get_attention_mask(), &device))
+                        .collect::<candle_core::Result<Vec<_>>>()?,
+                    0,
+                )?;
+                let token_type_ids = token_ids.zeros_like()?;
+                let embeddings = model.forward(
+                    &token_ids,
+                    &attention_mask,
+                    &token_type_ids,
+                    None,
+                    None,
+                    None,
+                )?;
+                (encodings, embeddings)
+            }
+        };
 
-        let token_ids = Tensor::stack(
-            &encodings
-                .iter()
-                .map(|e| Tensor::new(e.get_ids(), &device))
-                .collect::<candle_core::Result<Vec<_>>>()?,
-            0,
-        )?;
+        // Mean pooling with attention mask
         let attention_mask = Tensor::stack(
             &encodings
                 .iter()
@@ -312,14 +377,6 @@ impl CandleSession {
                 .collect::<candle_core::Result<Vec<_>>>()?,
             0,
         )?;
-        let token_type_ids = token_ids.zeros_like()?;
-
-        // Forward: [batch, seq_len, hidden_size]
-        let embeddings = self
-            .model
-            .forward(&token_ids, &token_type_ids, Some(&attention_mask))?;
-
-        // Mean pooling with attention mask
         let mask_f = attention_mask.to_dtype(DTYPE)?.unsqueeze(2)?;
         let sum_mask = mask_f.sum(1)?;
         let pooled = (embeddings.broadcast_mul(&mask_f)?)

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -780,8 +780,8 @@ fn run_full_vector_indexing(
     };
 
     if !files_to_index.is_empty() {
-        // Filter: skip projects where vector_index = false (default).
-        // Only projects with explicit `vector_index = true` in alcove.toml are embedded.
+        // Filter: skip projects where vector_index resolves to false.
+        // Projects inherit vector_index from global config unless overridden locally.
         // Also skip files already present in the vector store (incremental indexing).
         let to_embed: Vec<ProjectFile> = files_to_index
             .into_iter()

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -788,7 +788,7 @@ fn run_full_vector_indexing(
             .filter(|(proj, rel, _)| {
                 let proj_path = docs_root.join(proj);
                 let proj_cfg = effective_config(&proj_path);
-                if !proj_cfg.vector_index {
+                if !proj_cfg.vector_index.unwrap_or(false) {
                     return false;
                 }
                 !matches!(store.has_file(proj, rel), Ok(true))
@@ -852,7 +852,7 @@ fn count_vector_skipped_projects(docs_root: &Path) -> u64 {
                 return false;
             }
             // A project is "skipped" when vector_index is false (the default).
-            !effective_config(&path).vector_index
+            !effective_config(&path).vector_index.unwrap_or(false)
         })
         .count() as u64
 }


### PR DESCRIPTION
## Summary
BGE-M3 임베딩 모델 지원을 위해 XLM-RoBERTa 아키텍처 로더를 추가합니다. 기존 BERT 모델들과 함께 BGE-M3를 사용할 수 있으며, `pytorch_model.bin` 폴백과 `ALCOVE_EMBEDDING_MODEL` 환경변수 오버라이드도 포함합니다.

## Spec
- ID: SPEC-20260522T164836Z
- Requirements: R1, R2, R3, R4, R5

## Changes
- `src/embedding.rs`: `ModelSession` enum (Bert/XlmRoberta), 공통 텐서 생성 후 `model.forward()`만 분기, `pytorch_model.bin` 3단계 폴백 (safetensors → index.json → pytorch), SAFETY 주석
- `src/config.rs`: `vector_index`를 `Option<bool>`로 변경하여 명시적 false와 기본값(None) 구분, `ALCOVE_EMBEDDING_MODEL` env var 오버라이드
- `src/index/builder.rs`: `vector_index.unwrap_or(false)` 접근 방식 업데이트
- `README.md` + 10개 번역: CLI 명령어 이름 동기화

## Acceptance Criteria Verified
- AC1: ✅ `alcove model download` succeeds (BGEM3 model_id = `BAAI/bge-m3`)
- AC2: ✅ XLM-RoBERTa 로드 경로 구현됨
- AC3: ✅ AllMiniLML6V2 리빌드로 8699 벡터 생성 확인
- AC4: ✅ BGEM3 dimension = 1024 (`embedding.rs:78`)
- AC5: ✅ `cargo clippy --features "embed-candle,vector" -- -D warnings` passes
- AC6: ✅ 471/471 tests pass

## Check Report
- Code Quality: **PASS** — 모든 스펙 요구사항 정확히 반영, API 서명 일치
- Security: **PASS** — unsafe 블록 SAFETY 주석 확인, env var 주입 벡터 없음, 시크릿 노출 없음
- Performance: **PASS** — 텐서 생성 중복 제거, Option<bool> 오버헤드 제로
- Tests: **471/471 PASS**, 0 fail
- Spec Coverage: R1✅ R2✅ R3✅ R4✅ R5✅

## Test Plan
- [x] Unit tests pass (471/471)
- [x] Clippy clean with `embed-candle,vector` features
- [x] Fmt check clean
- [x] Isolated integration test (release build + full suite) PASS
- [x] `ALCOVE_EMBEDDING_MODEL=AllMiniLML6V2 alcove rebuild` produces vectors
- [ ] BGEM3 full rebuild (requires 2.3GB download + disk space)