### PR TITLE
feat(config): add multi doc-root support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -376,7 +376,7 @@ pub struct ResolvedDocRoot {
     pub name: String,
     pub path: PathBuf,
     /// Per-root embedding override, if configured.
-    /// Stored for future per-root model selection; not yet consumed by the indexer.
+    /// TODO: wire per-root embedding into the index builder.
     #[cfg(feature = "embed-candle")]
     #[allow(dead_code)]
     pub embedding: Option<EmbeddingConfig>,
@@ -390,6 +390,31 @@ fn expand_tilde(s: &str) -> PathBuf {
         return home.join(stripped);
     }
     PathBuf::from(s)
+}
+
+/// Shared logic for resolving a single-root path: expand tilde, canonicalize,
+/// check for blocked system paths, and verify the directory exists.
+fn resolve_single_root(raw: &str, label: &str) -> Option<Vec<ResolvedDocRoot>> {
+    let expanded = expand_tilde(raw);
+    let canonical = expanded.canonicalize().unwrap_or(expanded);
+    if is_blocked_system_path(&canonical) {
+        eprintln!(
+            "[alcove] {} points to blocked system path: {} — skipping",
+            label,
+            canonical.display()
+        );
+        return None;
+    }
+    if !canonical.is_dir() {
+        eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
+        return None;
+    }
+    Some(vec![ResolvedDocRoot {
+        name: "default".into(),
+        path: canonical,
+        #[cfg(feature = "embed-candle")]
+        embedding: None,
+    }])
 }
 
 impl DocRootEntry {
@@ -548,74 +573,55 @@ impl DocConfig {
     ///
     /// Returns an empty Vec if no root is configured or discoverable.
     pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
-        // 1. DOCS_ROOT env var — highest priority single-root override
-        if let Ok(v) = std::env::var("DOCS_ROOT") {
-            let raw = expand_tilde(&v);
-            let canonical = raw.canonicalize().unwrap_or(raw);
-            if is_blocked_system_path(&canonical) {
-                eprintln!(
-                    "[alcove] DOCS_ROOT points to blocked system path: {} — skipping",
-                    canonical.display()
-                );
-            } else if canonical.is_dir() {
-                return vec![ResolvedDocRoot {
-                    name: "default".into(),
-                    path: canonical,
+        Self::roots_from_env()
+            .or_else(|| self.roots_from_legacy_field())
+            .or_else(|| self.roots_from_multi_field())
+            .or_else(Self::roots_from_builtin_default)
+            .unwrap_or_default()
+    }
+
+    /// Priority 1: `DOCS_ROOT` env var — highest priority single-root override.
+    fn roots_from_env() -> Option<Vec<ResolvedDocRoot>> {
+        let v = std::env::var("DOCS_ROOT").ok()?;
+        resolve_single_root(&v, "DOCS_ROOT")
+    }
+
+    /// Priority 2: Legacy single `docs_root` field.
+    fn roots_from_legacy_field(&self) -> Option<Vec<ResolvedDocRoot>> {
+        let root = self.docs_root.as_ref()?;
+        resolve_single_root(root, "docs_root")
+    }
+
+    /// Priority 3: Multiple named `docs_roots` entries.
+    fn roots_from_multi_field(&self) -> Option<Vec<ResolvedDocRoot>> {
+        let entries = self.docs_roots.as_ref()?;
+        let roots: Vec<ResolvedDocRoot> = entries
+            .iter()
+            .filter_map(|e| {
+                e.expand_path().map(|path| ResolvedDocRoot {
+                    name: e.name.clone(),
+                    path,
                     #[cfg(feature = "embed-candle")]
-                    embedding: None,
-                }];
-            } else {
-                eprintln!("[alcove] DOCS_ROOT '{}' does not exist — skipping", v);
-            }
-        }
-        // 2. Legacy single docs_root field
-        if let Some(ref root) = self.docs_root {
-            let raw = expand_tilde(root);
-            let canonical = raw.canonicalize().unwrap_or(raw);
-            if is_blocked_system_path(&canonical) {
-                eprintln!(
-                    "[alcove] docs_root points to blocked system path: {} — skipping",
-                    canonical.display()
-                );
-            } else if canonical.is_dir() {
-                return vec![ResolvedDocRoot {
-                    name: "default".into(),
-                    path: canonical,
-                    #[cfg(feature = "embed-candle")]
-                    embedding: None,
-                }];
-            } else {
-                eprintln!("[alcove] docs_root '{}' does not exist — skipping", root);
-            }
-        }
-        // 3. Multi docs_roots
-        if let Some(ref entries) = self.docs_roots {
-            let roots: Vec<ResolvedDocRoot> = entries
-                .iter()
-                .filter_map(|e| {
-                    e.expand_path().map(|path| ResolvedDocRoot {
-                        name: e.name.clone(),
-                        path,
-                        #[cfg(feature = "embed-candle")]
-                        embedding: e.embedding.clone(),
-                    })
+                    embedding: e.embedding.clone(),
                 })
-                .collect();
-            if !roots.is_empty() {
-                return roots;
-            }
-        }
-        // 4. Built-in default
+            })
+            .collect();
+        if roots.is_empty() { None } else { Some(roots) }
+    }
+
+    /// Priority 4: Built-in default (`~/.alcove/docs`) if the directory exists.
+    fn roots_from_builtin_default() -> Option<Vec<ResolvedDocRoot>> {
         let fallback = default_docs_root();
         if fallback.is_dir() {
-            return vec![ResolvedDocRoot {
+            Some(vec![ResolvedDocRoot {
                 name: "default".into(),
                 path: fallback,
                 #[cfg(feature = "embed-candle")]
                 embedding: None,
-            }];
+            }])
+        } else {
+            None
         }
-        vec![]
     }
 
     #[cfg_attr(test, allow(dead_code))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1182,48 +1182,41 @@ mod tests {
 
     #[test]
     fn resolved_docs_roots_uses_docs_roots_vec() {
-        // docs_roots should be used when no DOCS_ROOT env var and no docs_root field.
-        // We set docs_root to a non-existent path so the legacy branch is skipped,
-        // which forces the docs_roots vec to be evaluated.
+        // Use a tempdir under ~/.alcove/test-* so paths are outside /tmp
+        // and pass is_blocked_system_path.
+        let base = alcove_home().join(format!("test-multi-root-{}", std::process::id()));
+        let oss_path = base.join("oss");
+        let work_path = base.join("work");
+        std::fs::create_dir_all(&oss_path).unwrap();
+        std::fs::create_dir_all(&work_path).unwrap();
+
+        // docs_root takes precedence over docs_roots.
         let cfg = DocConfig {
-            docs_root: Some("/tmp/nonexistent-alcove-test-root-xyz".into()),
-            docs_roots: Some(vec![
-                DocRootEntry {
-                    name: "oss".into(),
-                    path: "/tmp/oss".into(),
-                    #[cfg(feature = "embed-candle")]
-                    embedding: None,
-                },
-                DocRootEntry {
-                    name: "work".into(),
-                    path: "/tmp/work".into(),
-                    #[cfg(feature = "embed-candle")]
-                    embedding: None,
-                },
-            ]),
+            docs_root: Some(oss_path.to_string_lossy().to_string()),
+            docs_roots: Some(vec![DocRootEntry {
+                name: "work".into(),
+                path: work_path.to_string_lossy().to_string(),
+                #[cfg(feature = "embed-candle")]
+                embedding: None,
+            }]),
             ..DocConfig::default()
         };
-        // docs_root takes precedence over docs_roots — verify the field works at all.
         let roots = cfg.resolved_docs_roots();
-        // docs_root field is set → that single root wins.
-        assert_eq!(roots.len(), 1);
-        assert_eq!(
-            roots[0].path,
-            PathBuf::from("/tmp/nonexistent-alcove-test-root-xyz")
-        );
+        assert_eq!(roots.len(), 1, "docs_root must win over docs_roots");
+        assert_eq!(roots[0].path, oss_path);
 
-        // Now test docs_roots alone (no docs_root field).
+        // docs_roots alone (no docs_root field).
         let cfg2 = DocConfig {
             docs_roots: Some(vec![
                 DocRootEntry {
                     name: "oss".into(),
-                    path: "/tmp/oss".into(),
+                    path: oss_path.to_string_lossy().to_string(),
                     #[cfg(feature = "embed-candle")]
                     embedding: None,
                 },
                 DocRootEntry {
                     name: "work".into(),
-                    path: "/tmp/work".into(),
+                    path: work_path.to_string_lossy().to_string(),
                     #[cfg(feature = "embed-candle")]
                     embedding: None,
                 },
@@ -1231,26 +1224,25 @@ mod tests {
             ..DocConfig::default()
         };
         let roots2 = cfg2.resolved_docs_roots();
-        // Should have exactly 2 entries (docs_roots) — unless the default ~/.alcove/docs
-        // happens to exist on the test machine, in which case it falls through to fallback.
-        // Just assert the names are correct when len == 2.
-        if roots2.len() == 2 {
-            assert_eq!(roots2[0].name, "oss");
-            assert_eq!(roots2[1].name, "work");
-        } else {
-            // Default dir exists on this machine; can't isolate without temp dir tricks.
-            // Accept any non-zero count.
-            assert!(!roots2.is_empty());
-        }
+        assert_eq!(roots2.len(), 2);
+        assert_eq!(roots2[0].name, "oss");
+        assert_eq!(roots2[1].name, "work");
+
+        let _ = std::fs::remove_dir_all(&base); // cleanup
     }
 
     #[test]
     fn resolved_docs_roots_legacy_takes_precedence_over_vec() {
+        let base = alcove_home().join(format!("test-legacy-root-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
         let cfg = DocConfig {
-            docs_root: Some("/tmp/legacy".into()),
+            docs_root: Some(base.to_string_lossy().to_string()),
             docs_roots: Some(vec![DocRootEntry {
                 name: "oss".into(),
-                path: "/tmp/oss".into(),
+                path: alcove_home()
+                    .join("test-oss-root")
+                    .to_string_lossy()
+                    .to_string(),
                 #[cfg(feature = "embed-candle")]
                 embedding: None,
             }]),
@@ -1259,7 +1251,9 @@ mod tests {
         // legacy docs_root takes precedence
         let roots = cfg.resolved_docs_roots();
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, PathBuf::from("/tmp/legacy"));
+        assert_eq!(roots[0].path, base);
+
+        let _ = std::fs::remove_dir_all(&base); // cleanup
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -545,11 +545,12 @@ impl DocConfig {
     pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
         // 1. DOCS_ROOT env var — highest priority single-root override
         if let Ok(v) = std::env::var("DOCS_ROOT") {
-            let path = PathBuf::from(&v);
-            if !is_blocked_system_path(&path) {
+            let raw = PathBuf::from(&v);
+            let canonical = raw.canonicalize().unwrap_or(raw);
+            if !is_blocked_system_path(&canonical) {
                 return vec![ResolvedDocRoot {
                     name: "default".into(),
-                    path,
+                    path: canonical,
                     #[cfg(feature = "embed-candle")]
                     embedding: None,
                 }];
@@ -557,13 +558,21 @@ impl DocConfig {
         }
         // 2. Legacy single docs_root field
         if let Some(ref root) = self.docs_root {
-            let path = PathBuf::from(root);
-            return vec![ResolvedDocRoot {
-                name: "default".into(),
-                path,
-                #[cfg(feature = "embed-candle")]
-                embedding: None,
-            }];
+            let raw = PathBuf::from(root);
+            let canonical = raw.canonicalize().unwrap_or(raw);
+            if is_blocked_system_path(&canonical) {
+                eprintln!(
+                    "[alcove] docs_root points to blocked system path: {} — skipping",
+                    canonical.display()
+                );
+            } else {
+                return vec![ResolvedDocRoot {
+                    name: "default".into(),
+                    path: canonical,
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                }];
+            }
         }
         // 3. Multi docs_roots
         if let Some(ref entries) = self.docs_roots {
@@ -1183,16 +1192,20 @@ mod tests {
 
     #[test]
     fn resolved_docs_roots_uses_legacy_docs_root() {
+        let base = alcove_home().join(format!("test-legacy-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
         let cfg = DocConfig {
-            docs_root: Some("/tmp/legacy".into()),
+            docs_root: Some(base.to_string_lossy().to_string()),
             ..DocConfig::default()
         };
         let roots = cfg.resolved_docs_roots();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].name, "default");
-        assert_eq!(roots[0].path, PathBuf::from("/tmp/legacy"));
+        // canonicalize resolves to the same absolute path
+        assert!(roots[0].path.is_absolute());
         #[cfg(feature = "embed-candle")]
         assert!(roots[0].embedding.is_none());
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]
@@ -1218,7 +1231,11 @@ mod tests {
         };
         let roots = cfg.resolved_docs_roots();
         assert_eq!(roots.len(), 1, "docs_root must win over docs_roots");
-        assert_eq!(roots[0].path, oss_path);
+        // Path is canonicalized, so compare with canonical form
+        assert_eq!(
+            roots[0].path,
+            oss_path.canonicalize().unwrap_or(oss_path.clone())
+        );
 
         // docs_roots alone (no docs_root field).
         let cfg2 = DocConfig {
@@ -1266,7 +1283,7 @@ mod tests {
         // legacy docs_root takes precedence
         let roots = cfg.resolved_docs_roots();
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, base);
+        assert_eq!(roots[0].path, base.canonicalize().unwrap_or(base.clone()));
 
         let _ = std::fs::remove_dir_all(&base); // cleanup
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -565,10 +565,7 @@ impl DocConfig {
                     embedding: None,
                 }];
             } else {
-                eprintln!(
-                    "[alcove] DOCS_ROOT '{}' does not exist — skipping",
-                    v
-                );
+                eprintln!("[alcove] DOCS_ROOT '{}' does not exist — skipping", v);
             }
         }
         // 2. Legacy single docs_root field
@@ -588,10 +585,7 @@ impl DocConfig {
                     embedding: None,
                 }];
             } else {
-                eprintln!(
-                    "[alcove] docs_root '{}' does not exist — skipping",
-                    root
-                );
+                eprintln!("[alcove] docs_root '{}' does not exist — skipping", root);
             }
         }
         // 3. Multi docs_roots

--- a/src/config.rs
+++ b/src/config.rs
@@ -382,17 +382,21 @@ pub struct ResolvedDocRoot {
     pub embedding: Option<EmbeddingConfig>,
 }
 
+/// Expand a leading `~/` to the user's home directory.
+fn expand_tilde(s: &str) -> PathBuf {
+    if let Some(stripped) = s.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(stripped);
+    }
+    PathBuf::from(s)
+}
+
 impl DocRootEntry {
     /// Expand `~` prefix and canonicalize the path.
     /// Returns `None` if the resolved path points to a blocked system directory.
     fn expand_path(&self) -> Option<PathBuf> {
-        let expanded = if self.path.starts_with("~/")
-            && let Some(home) = dirs::home_dir()
-        {
-            home.join(&self.path[2..])
-        } else {
-            PathBuf::from(&self.path)
-        };
+        let expanded = expand_tilde(&self.path);
         // Canonicalize to resolve symlinks / `..` traversal, then check safety.
         let canonical = expanded.canonicalize().unwrap_or(expanded);
         if is_blocked_system_path(&canonical) {
@@ -546,7 +550,7 @@ impl DocConfig {
     pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
         // 1. DOCS_ROOT env var — highest priority single-root override
         if let Ok(v) = std::env::var("DOCS_ROOT") {
-            let raw = PathBuf::from(&v);
+            let raw = expand_tilde(&v);
             let canonical = raw.canonicalize().unwrap_or(raw);
             if is_blocked_system_path(&canonical) {
                 eprintln!(
@@ -569,7 +573,7 @@ impl DocConfig {
         }
         // 2. Legacy single docs_root field
         if let Some(ref root) = self.docs_root {
-            let raw = PathBuf::from(root);
+            let raw = expand_tilde(root);
             let canonical = raw.canonicalize().unwrap_or(raw);
             if is_blocked_system_path(&canonical) {
                 eprintln!(
@@ -1288,38 +1292,68 @@ mod tests {
     }
 
     #[test]
-    fn resolved_docs_roots_legacy_takes_precedence_over_vec() {
-        let base = alcove_home().join(format!("test-legacy-root-{}", std::process::id()));
-        std::fs::create_dir_all(&base).unwrap();
-        let _guard = TempDir(base.clone());
-        let cfg = DocConfig {
-            docs_root: Some(base.to_string_lossy().to_string()),
-            docs_roots: Some(vec![DocRootEntry {
-                name: "oss".into(),
-                path: alcove_home()
-                    .join("test-oss-root")
-                    .to_string_lossy()
-                    .to_string(),
-                #[cfg(feature = "embed-candle")]
-                embedding: None,
-            }]),
-            ..DocConfig::default()
-        };
-        // legacy docs_root takes precedence
-        let roots = cfg.resolved_docs_roots();
-        assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, base.canonicalize().unwrap_or(base.clone()));
-    }
-
-    #[test]
     fn resolved_docs_roots_empty_when_nothing_configured() {
-        // Ensure ~/.alcove/docs does NOT exist during this test.
-        // Since we can't control the env safely, just verify the method returns
-        // a consistent type — no panic.
+        // Since we can't control whether ~/.alcove/docs exists in the test env,
+        // just verify no panic and a bounded return.
         let cfg = DocConfig::default();
         let roots = cfg.resolved_docs_roots();
         // Either 0 (no default dir) or 1 (default dir exists) — both valid.
         assert!(roots.len() <= 1);
+    }
+
+    #[test]
+    fn resolved_docs_roots_expands_tilde_in_docs_root() {
+        // Construct a path that starts with "~/" and verify it resolves to an
+        // absolute path (i.e. the tilde was expanded).
+        let home = dirs::home_dir().expect("home dir must exist for this test");
+        // Point at ~/.alcove itself — guaranteed to exist on any dev machine
+        // that has alcove installed, but safe to test even if it doesn't because
+        // we only check that the path is absolute, not that it's a dir.
+        let tilde_path = "~/.alcove".to_string();
+        let cfg = DocConfig {
+            docs_root: Some(tilde_path),
+            ..DocConfig::default()
+        };
+        let roots = cfg.resolved_docs_roots();
+        // If ~/.alcove exists as a dir we get one root; if not, zero. Either way
+        // verify the returned path (if any) does NOT contain a literal "~".
+        for r in &roots {
+            assert!(
+                r.path.is_absolute(),
+                "tilde must have been expanded: {:?}",
+                r.path
+            );
+            assert!(
+                !r.path.starts_with("~"),
+                "literal tilde must not appear in resolved path: {:?}",
+                r.path
+            );
+        }
+        // Sanity: the resolved path, when it exists, should start with home.
+        if !roots.is_empty() && roots[0].path.exists() {
+            assert!(roots[0].path.starts_with(&home));
+        }
+    }
+
+    #[test]
+    fn resolved_docs_roots_blocked_docs_root_skips_to_fallback() {
+        // Setting docs_root to a blocked path (e.g. /tmp which is blocked by
+        // is_blocked_system_path) should skip that entry and fall through to
+        // the default fallback, not panic.
+        let cfg = DocConfig {
+            docs_root: Some("/tmp".to_string()),
+            ..DocConfig::default()
+        };
+        // Should not panic; may return 0 or 1 roots depending on default dir.
+        let roots = cfg.resolved_docs_roots();
+        // /tmp must never appear in the results.
+        for r in &roots {
+            assert_ne!(
+                r.path.to_string_lossy().as_ref(),
+                "/tmp",
+                "blocked path must not appear in resolved roots"
+            );
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,6 +376,7 @@ pub struct ResolvedDocRoot {
     pub name: String,
     pub path: PathBuf,
     /// Per-root embedding override, if configured.
+    /// Stored for future per-root model selection; not yet consumed by the indexer.
     #[cfg(feature = "embed-candle")]
     #[allow(dead_code)]
     pub embedding: Option<EmbeddingConfig>,
@@ -547,13 +548,23 @@ impl DocConfig {
         if let Ok(v) = std::env::var("DOCS_ROOT") {
             let raw = PathBuf::from(&v);
             let canonical = raw.canonicalize().unwrap_or(raw);
-            if !is_blocked_system_path(&canonical) {
+            if is_blocked_system_path(&canonical) {
+                eprintln!(
+                    "[alcove] DOCS_ROOT points to blocked system path: {} — skipping",
+                    canonical.display()
+                );
+            } else if canonical.is_dir() {
                 return vec![ResolvedDocRoot {
                     name: "default".into(),
                     path: canonical,
                     #[cfg(feature = "embed-candle")]
                     embedding: None,
                 }];
+            } else {
+                eprintln!(
+                    "[alcove] DOCS_ROOT '{}' does not exist — skipping",
+                    v
+                );
             }
         }
         // 2. Legacy single docs_root field
@@ -565,13 +576,18 @@ impl DocConfig {
                     "[alcove] docs_root points to blocked system path: {} — skipping",
                     canonical.display()
                 );
-            } else {
+            } else if canonical.is_dir() {
                 return vec![ResolvedDocRoot {
                     name: "default".into(),
                     path: canonical,
                     #[cfg(feature = "embed-candle")]
                     embedding: None,
                 }];
+            } else {
+                eprintln!(
+                    "[alcove] docs_root '{}' does not exist — skipping",
+                    root
+                );
             }
         }
         // 3. Multi docs_roots
@@ -1190,10 +1206,20 @@ mod tests {
 
     // -- resolved_docs_roots --
 
+    /// RAII guard: removes `path` on drop so test directories are cleaned up
+    /// even when an assertion panics.
+    struct TempDir(std::path::PathBuf);
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
     #[test]
     fn resolved_docs_roots_uses_legacy_docs_root() {
         let base = alcove_home().join(format!("test-legacy-{}", std::process::id()));
         std::fs::create_dir_all(&base).unwrap();
+        let _guard = TempDir(base.clone());
         let cfg = DocConfig {
             docs_root: Some(base.to_string_lossy().to_string()),
             ..DocConfig::default()
@@ -1205,7 +1231,6 @@ mod tests {
         assert!(roots[0].path.is_absolute());
         #[cfg(feature = "embed-candle")]
         assert!(roots[0].embedding.is_none());
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]
@@ -1217,6 +1242,7 @@ mod tests {
         let work_path = base.join("work");
         std::fs::create_dir_all(&oss_path).unwrap();
         std::fs::create_dir_all(&work_path).unwrap();
+        let _guard = TempDir(base.clone());
 
         // docs_root takes precedence over docs_roots.
         let cfg = DocConfig {
@@ -1259,14 +1285,13 @@ mod tests {
         assert_eq!(roots2.len(), 2);
         assert_eq!(roots2[0].name, "oss");
         assert_eq!(roots2[1].name, "work");
-
-        let _ = std::fs::remove_dir_all(&base); // cleanup
     }
 
     #[test]
     fn resolved_docs_roots_legacy_takes_precedence_over_vec() {
         let base = alcove_home().join(format!("test-legacy-root-{}", std::process::id()));
         std::fs::create_dir_all(&base).unwrap();
+        let _guard = TempDir(base.clone());
         let cfg = DocConfig {
             docs_root: Some(base.to_string_lossy().to_string()),
             docs_roots: Some(vec![DocRootEntry {
@@ -1284,8 +1309,6 @@ mod tests {
         let roots = cfg.resolved_docs_roots();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].path, base.canonicalize().unwrap_or(base.clone()));
-
-        let _ = std::fs::remove_dir_all(&base); // cleanup
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -430,7 +430,13 @@ fn expand_tilde(s: &str) -> PathBuf {
 /// the caller's priority chain to fall through to the next source.
 fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
     let expanded = expand_tilde(raw);
-    let canonical = expanded.canonicalize().unwrap_or(expanded);
+    let canonical = match expanded.canonicalize() {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
+            return None;
+        }
+    };
     if is_blocked_system_path(&canonical) {
         eprintln!(
             "[alcove] {} points to blocked system path: {} — skipping",
@@ -440,7 +446,7 @@ fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
         return None;
     }
     if !canonical.is_dir() {
-        eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
+        eprintln!("[alcove] {} '{}' is not a directory — skipping", label, raw);
         return None;
     }
     Some(ResolvedDocRoot::new_default(canonical))

--- a/src/config.rs
+++ b/src/config.rs
@@ -382,13 +382,27 @@ pub struct ResolvedDocRoot {
 }
 
 impl DocRootEntry {
-    fn expand_path(&self) -> PathBuf {
-        if self.path.starts_with("~/")
+    /// Expand `~` prefix and canonicalize the path.
+    /// Returns `None` if the resolved path points to a blocked system directory.
+    fn expand_path(&self) -> Option<PathBuf> {
+        let expanded = if self.path.starts_with("~/")
             && let Some(home) = dirs::home_dir()
         {
-            return home.join(&self.path[2..]);
+            home.join(&self.path[2..])
+        } else {
+            PathBuf::from(&self.path)
+        };
+        // Canonicalize to resolve symlinks / `..` traversal, then check safety.
+        let canonical = expanded.canonicalize().unwrap_or(expanded);
+        if is_blocked_system_path(&canonical) {
+            eprintln!(
+                "[alcove] docs_roots entry '{}' points to blocked system path: {} — skipping",
+                self.name,
+                canonical.display()
+            );
+            return None;
         }
-        PathBuf::from(&self.path)
+        Some(canonical)
     }
 }
 
@@ -529,7 +543,7 @@ impl DocConfig {
     ///
     /// Returns an empty Vec if no root is configured or discoverable.
     pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
-        // 1. DOCS_ROOT env var (handled in mcp.rs, but honour here too)
+        // 1. DOCS_ROOT env var — highest priority single-root override
         if let Ok(v) = std::env::var("DOCS_ROOT") {
             let path = PathBuf::from(&v);
             if !is_blocked_system_path(&path) {
@@ -555,13 +569,14 @@ impl DocConfig {
         if let Some(ref entries) = self.docs_roots {
             let roots: Vec<ResolvedDocRoot> = entries
                 .iter()
-                .map(|e| ResolvedDocRoot {
-                    name: e.name.clone(),
-                    path: e.expand_path(),
-                    #[cfg(feature = "embed-candle")]
-                    embedding: e.embedding.clone(),
+                .filter_map(|e| {
+                    e.expand_path().map(|path| ResolvedDocRoot {
+                        name: e.name.clone(),
+                        path,
+                        #[cfg(feature = "embed-candle")]
+                        embedding: e.embedding.clone(),
+                    })
                 })
-                .filter(|r| !is_blocked_system_path(&r.path))
                 .collect();
             if !roots.is_empty() {
                 return roots;

--- a/src/config.rs
+++ b/src/config.rs
@@ -383,7 +383,9 @@ pub struct ResolvedDocRoot {
 
 impl DocRootEntry {
     fn expand_path(&self) -> PathBuf {
-        if self.path.starts_with("~/") && let Some(home) = dirs::home_dir() {
+        if self.path.starts_with("~/")
+            && let Some(home) = dirs::home_dir()
+        {
             return home.join(&self.path[2..]);
         }
         PathBuf::from(&self.path)
@@ -1205,7 +1207,10 @@ mod tests {
         let roots = cfg.resolved_docs_roots();
         // docs_root field is set → that single root wins.
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, PathBuf::from("/tmp/nonexistent-alcove-test-root-xyz"));
+        assert_eq!(
+            roots[0].path,
+            PathBuf::from("/tmp/nonexistent-alcove-test-root-xyz")
+        );
 
         // Now test docs_roots alone (no docs_root field).
         let cfg2 = DocConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,17 +365,22 @@ pub struct DocRootEntry {
     /// Filesystem path (tilde-expanded at runtime).
     pub path: String,
     /// Per-root embedding override.  Falls back to global `[embedding]` when absent.
+    /// NOTE: cfg-gate must stay in sync with `ResolvedDocRoot.embedding`.
     #[cfg(feature = "embed-candle")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<EmbeddingConfig>,
 }
 
 /// A resolved `DocRootEntry` with the path expanded and validated.
+///
+/// `path` is always stored in canonical form (via `canonicalize()` during
+/// resolution), so callers can rely on it being absolute with symlinks resolved.
 #[derive(Debug, Clone)]
 pub struct ResolvedDocRoot {
     pub name: String,
     pub path: PathBuf,
     /// Per-root embedding override, if configured.
+    /// NOTE: cfg-gate must stay in sync with `DocRootEntry.embedding`.
     /// TODO: wire per-root embedding into the index builder.
     #[cfg(feature = "embed-candle")]
     #[allow(dead_code)]
@@ -406,19 +411,40 @@ fn expand_tilde(s: &str) -> PathBuf {
 
 /// Shared logic for resolving a single-root path: expand tilde, canonicalize,
 /// check for blocked system paths, and verify the directory exists.
-fn resolve_single_root(raw: &str, label: &str) -> Option<Vec<ResolvedDocRoot>> {
+///
+/// When `is_fatal` is true (highest-priority sources: env var, legacy field),
+/// a blocked or missing path is treated as a hard error — the caller should not
+/// fall through to lower-priority sources. When false, the path is silently skipped.
+fn resolve_single_root(raw: &str, label: &str, is_fatal: bool) -> Option<Vec<ResolvedDocRoot>> {
     let expanded = expand_tilde(raw);
     let canonical = expanded.canonicalize().unwrap_or(expanded);
     if is_blocked_system_path(&canonical) {
-        eprintln!(
-            "[alcove] {} points to blocked system path: {} — skipping",
-            label,
-            canonical.display()
-        );
+        if is_fatal {
+            eprintln!(
+                "[alcove] ERROR: {} points to blocked system path: {}. \
+                 This is a high-priority source — will NOT fall back to lower-priority roots.",
+                label,
+                canonical.display()
+            );
+        } else {
+            eprintln!(
+                "[alcove] {} points to blocked system path: {} — skipping",
+                label,
+                canonical.display()
+            );
+        }
         return None;
     }
     if !canonical.is_dir() {
-        eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
+        if is_fatal {
+            eprintln!(
+                "[alcove] ERROR: {} '{}' does not exist. \
+                 This is a high-priority source — will NOT fall back to lower-priority roots.",
+                label, raw
+            );
+        } else {
+            eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
+        }
         return None;
     }
     Some(vec![ResolvedDocRoot::new_default(canonical)])
@@ -590,13 +616,13 @@ impl DocConfig {
     /// Priority 1: `DOCS_ROOT` env var — highest priority single-root override.
     fn roots_from_env() -> Option<Vec<ResolvedDocRoot>> {
         let v = std::env::var("DOCS_ROOT").ok()?;
-        resolve_single_root(&v, "DOCS_ROOT")
+        resolve_single_root(&v, "DOCS_ROOT", true)
     }
 
     /// Priority 2: Legacy single `docs_root` field.
     fn roots_from_legacy_field(&self) -> Option<Vec<ResolvedDocRoot>> {
         let root = self.docs_root.as_ref()?;
-        resolve_single_root(root, "docs_root")
+        resolve_single_root(root, "docs_root", true)
     }
 
     /// Priority 3: Multiple named `docs_roots` entries.
@@ -608,6 +634,8 @@ impl DocConfig {
                 e.expand_path().map(|path| ResolvedDocRoot {
                     name: e.name.clone(),
                     path,
+                    // cfg-gate sync: must match `ResolvedDocRoot.embedding` and
+                    // `DocRootEntry.embedding` — all three use `#[cfg(feature = "embed-candle")]`.
                     #[cfg(feature = "embed-candle")]
                     embedding: e.embedding.clone(),
                 })

--- a/src/config.rs
+++ b/src/config.rs
@@ -382,6 +382,18 @@ pub struct ResolvedDocRoot {
     pub embedding: Option<EmbeddingConfig>,
 }
 
+impl ResolvedDocRoot {
+    /// Create a single-root entry with the "default" name and no embedding override.
+    pub fn new_default(path: PathBuf) -> Self {
+        Self {
+            name: "default".into(),
+            path,
+            #[cfg(feature = "embed-candle")]
+            embedding: None,
+        }
+    }
+}
+
 /// Expand a leading `~/` to the user's home directory.
 fn expand_tilde(s: &str) -> PathBuf {
     if let Some(stripped) = s.strip_prefix("~/")
@@ -409,12 +421,7 @@ fn resolve_single_root(raw: &str, label: &str) -> Option<Vec<ResolvedDocRoot>> {
         eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
         return None;
     }
-    Some(vec![ResolvedDocRoot {
-        name: "default".into(),
-        path: canonical,
-        #[cfg(feature = "embed-candle")]
-        embedding: None,
-    }])
+    Some(vec![ResolvedDocRoot::new_default(canonical)])
 }
 
 impl DocRootEntry {
@@ -612,13 +619,17 @@ impl DocConfig {
     /// Priority 4: Built-in default (`~/.alcove/docs`) if the directory exists.
     fn roots_from_builtin_default() -> Option<Vec<ResolvedDocRoot>> {
         let fallback = default_docs_root();
-        if fallback.is_dir() {
-            Some(vec![ResolvedDocRoot {
-                name: "default".into(),
-                path: fallback,
-                #[cfg(feature = "embed-candle")]
-                embedding: None,
-            }])
+        // Use the same safety checks as resolve_single_root for consistency.
+        let canonical = fallback.canonicalize().unwrap_or(fallback);
+        if is_blocked_system_path(&canonical) {
+            eprintln!(
+                "[alcove] built-in default docs root points to blocked system path: {} — skipping",
+                canonical.display()
+            );
+            return None;
+        }
+        if canonical.is_dir() {
+            Some(vec![ResolvedDocRoot::new_default(canonical)])
         } else {
             None
         }
@@ -1354,6 +1365,16 @@ mod tests {
                 "blocked path must not appear in resolved roots"
             );
         }
+    }
+
+    #[test]
+    fn resolved_doc_root_new_default_creates_correct_entry() {
+        let path = PathBuf::from("/some/path");
+        let root = ResolvedDocRoot::new_default(path.clone());
+        assert_eq!(root.name, "default");
+        assert_eq!(root.path, path);
+        #[cfg(feature = "embed-candle")]
+        assert!(root.embedding.is_none());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -428,12 +428,12 @@ fn expand_tilde(s: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
-/// Shared logic for resolving a single-root path: expand tilde, canonicalize,
-/// check for blocked system paths, and verify the directory exists.
+/// Validate a doc-root candidate path: expand tilde, canonicalize, check for
+/// blocked system paths, and verify the path is a directory.
 ///
-/// Returns `None` (with a warning) if the path is blocked or missing, allowing
-/// the caller's priority chain to fall through to the next source.
-fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
+/// On failure, prints a diagnostic to stderr using `label` and `raw` for
+/// context, then returns `None` so the caller's priority chain can fall through.
+fn validate_doc_root_path(raw: &str, label: &str) -> Option<PathBuf> {
     let expanded = expand_tilde(raw);
     let canonical = match expanded.canonicalize() {
         Ok(c) => c,
@@ -454,41 +454,23 @@ fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
         eprintln!("[alcove] {} '{}' is not a directory — skipping", label, raw);
         return None;
     }
-    Some(ResolvedDocRoot::new_default(canonical))
+    Some(canonical)
+}
+
+/// Shared logic for resolving a single-root path.
+///
+/// Returns `None` (with a warning) if the path is blocked or missing, allowing
+/// the caller's priority chain to fall through to the next source.
+fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
+    validate_doc_root_path(raw, label).map(ResolvedDocRoot::new_default)
 }
 
 impl DocRootEntry {
     /// Expand `~` prefix and canonicalize the path.
     /// Returns `None` if the path doesn't exist, is not a directory, or points to a blocked system directory.
     fn expand_path(&self) -> Option<PathBuf> {
-        let expanded = expand_tilde(&self.path);
-        // Canonicalize to resolve symlinks / `..` traversal, then check safety.
-        let canonical = match expanded.canonicalize() {
-            Ok(c) => c,
-            Err(_) => {
-                eprintln!(
-                    "[alcove] docs_roots entry '{}' path '{}' does not exist — skipping",
-                    self.name, self.path
-                );
-                return None;
-            }
-        };
-        if is_blocked_system_path(&canonical) {
-            eprintln!(
-                "[alcove] docs_roots entry '{}' points to blocked system path: {} — skipping",
-                self.name,
-                canonical.display()
-            );
-            return None;
-        }
-        if !canonical.is_dir() {
-            eprintln!(
-                "[alcove] docs_roots entry '{}' path '{}' is not a directory — skipping",
-                self.name, self.path
-            );
-            return None;
-        }
-        Some(canonical)
+        let label = format!("docs_roots entry '{}'", self.name);
+        validate_doc_root_path(&self.path, &label)
     }
 }
 
@@ -628,6 +610,12 @@ impl DocConfig {
     ///   4. built-in default (`~/.alcove/docs`) if the directory exists
     ///
     /// Returns an empty Vec if no root is configured or discoverable.
+    ///
+    /// **Performance note**: this method performs filesystem I/O (`canonicalize` +
+    /// `is_dir`) for each configured root on every call.  It is called once per
+    /// MCP tool dispatch, which is acceptable for typical root counts (1–5).
+    /// TODO: cache the result at server startup when the number of roots or
+    /// call frequency grows large enough to make this a bottleneck.
     pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
         Self::roots_from_env()
             .or_else(|| self.roots_from_legacy_field())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1041,6 +1041,7 @@ pub fn is_doc_file(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn classify_core_files() {
@@ -1376,6 +1377,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolved_docs_roots_skips_nonexistent_docs_root_env() {
         // When DOCS_ROOT points to a non-existent path it is skipped, and the
         // chain falls through to the next source (legacy field, multi field, or

--- a/src/config.rs
+++ b/src/config.rs
@@ -377,6 +377,7 @@ pub struct ResolvedDocRoot {
     pub path: PathBuf,
     /// Per-root embedding override, if configured.
     #[cfg(feature = "embed-candle")]
+    #[allow(dead_code)]
     pub embedding: Option<EmbeddingConfig>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -448,11 +448,20 @@ fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
 
 impl DocRootEntry {
     /// Expand `~` prefix and canonicalize the path.
-    /// Returns `None` if the resolved path points to a blocked system directory.
+    /// Returns `None` if the path doesn't exist or points to a blocked system directory.
     fn expand_path(&self) -> Option<PathBuf> {
         let expanded = expand_tilde(&self.path);
         // Canonicalize to resolve symlinks / `..` traversal, then check safety.
-        let canonical = expanded.canonicalize().unwrap_or(expanded);
+        let canonical = match expanded.canonicalize() {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!(
+                    "[alcove] docs_roots entry '{}' path '{}' does not exist — skipping",
+                    self.name, self.path
+                );
+                return None;
+            }
+        };
         if is_blocked_system_path(&canonical) {
             eprintln!(
                 "[alcove] docs_roots entry '{}' points to blocked system path: {} — skipping",
@@ -631,7 +640,16 @@ impl DocConfig {
                     .map(|path| ResolvedDocRoot::from_entry(e, path))
             })
             .collect();
-        if roots.is_empty() { None } else { Some(roots) }
+        if roots.is_empty() {
+            eprintln!(
+                "[alcove] all {} configured docs_roots entries failed validation — \
+                 falling back to default",
+                entries.len()
+            );
+            None
+        } else {
+            Some(roots)
+        }
     }
 
     /// Priority 4: Built-in default (`~/.alcove/docs`) if the directory exists.

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,6 +397,20 @@ impl ResolvedDocRoot {
             embedding: None,
         }
     }
+
+    /// Create from a `DocRootEntry` with a pre-resolved canonical path.
+    ///
+    /// This is the single conversion point between the two types — the
+    /// `#[cfg(feature = "embed-candle")]` gate for the `embedding` field
+    /// only needs to be maintained here and in the struct definitions.
+    pub fn from_entry(entry: &DocRootEntry, canonical_path: PathBuf) -> Self {
+        Self {
+            name: entry.name.clone(),
+            path: canonical_path,
+            #[cfg(feature = "embed-candle")]
+            embedding: entry.embedding.clone(),
+        }
+    }
 }
 
 /// Expand a leading `~/` to the user's home directory.
@@ -412,42 +426,24 @@ fn expand_tilde(s: &str) -> PathBuf {
 /// Shared logic for resolving a single-root path: expand tilde, canonicalize,
 /// check for blocked system paths, and verify the directory exists.
 ///
-/// When `is_fatal` is true (highest-priority sources: env var, legacy field),
-/// a blocked or missing path is treated as a hard error — the caller should not
-/// fall through to lower-priority sources. When false, the path is silently skipped.
-fn resolve_single_root(raw: &str, label: &str, is_fatal: bool) -> Option<Vec<ResolvedDocRoot>> {
+/// Returns `None` (with a warning) if the path is blocked or missing, allowing
+/// the caller's priority chain to fall through to the next source.
+fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
     let expanded = expand_tilde(raw);
     let canonical = expanded.canonicalize().unwrap_or(expanded);
     if is_blocked_system_path(&canonical) {
-        if is_fatal {
-            eprintln!(
-                "[alcove] ERROR: {} points to blocked system path: {}. \
-                 This is a high-priority source — will NOT fall back to lower-priority roots.",
-                label,
-                canonical.display()
-            );
-        } else {
-            eprintln!(
-                "[alcove] {} points to blocked system path: {} — skipping",
-                label,
-                canonical.display()
-            );
-        }
+        eprintln!(
+            "[alcove] {} points to blocked system path: {} — skipping",
+            label,
+            canonical.display()
+        );
         return None;
     }
     if !canonical.is_dir() {
-        if is_fatal {
-            eprintln!(
-                "[alcove] ERROR: {} '{}' does not exist. \
-                 This is a high-priority source — will NOT fall back to lower-priority roots.",
-                label, raw
-            );
-        } else {
-            eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
-        }
+        eprintln!("[alcove] {} '{}' does not exist — skipping", label, raw);
         return None;
     }
-    Some(vec![ResolvedDocRoot::new_default(canonical)])
+    Some(ResolvedDocRoot::new_default(canonical))
 }
 
 impl DocRootEntry {
@@ -616,13 +612,13 @@ impl DocConfig {
     /// Priority 1: `DOCS_ROOT` env var — highest priority single-root override.
     fn roots_from_env() -> Option<Vec<ResolvedDocRoot>> {
         let v = std::env::var("DOCS_ROOT").ok()?;
-        resolve_single_root(&v, "DOCS_ROOT", true)
+        resolve_single_root(&v, "DOCS_ROOT").map(|r| vec![r])
     }
 
     /// Priority 2: Legacy single `docs_root` field.
     fn roots_from_legacy_field(&self) -> Option<Vec<ResolvedDocRoot>> {
         let root = self.docs_root.as_ref()?;
-        resolve_single_root(root, "docs_root", true)
+        resolve_single_root(root, "docs_root").map(|r| vec![r])
     }
 
     /// Priority 3: Multiple named `docs_roots` entries.
@@ -631,14 +627,8 @@ impl DocConfig {
         let roots: Vec<ResolvedDocRoot> = entries
             .iter()
             .filter_map(|e| {
-                e.expand_path().map(|path| ResolvedDocRoot {
-                    name: e.name.clone(),
-                    path,
-                    // cfg-gate sync: must match `ResolvedDocRoot.embedding` and
-                    // `DocRootEntry.embedding` — all three use `#[cfg(feature = "embed-candle")]`.
-                    #[cfg(feature = "embed-candle")]
-                    embedding: e.embedding.clone(),
-                })
+                e.expand_path()
+                    .map(|path| ResolvedDocRoot::from_entry(e, path))
             })
             .collect();
         if roots.is_empty() { None } else { Some(roots) }

--- a/src/config.rs
+++ b/src/config.rs
@@ -413,12 +413,17 @@ impl ResolvedDocRoot {
     }
 }
 
-/// Expand a leading `~/` to the user's home directory.
+/// Expand a leading `~` to the user's home directory.
+///
+/// Handles both `~/path` and bare `~` forms.
 fn expand_tilde(s: &str) -> PathBuf {
-    if let Some(stripped) = s.strip_prefix("~/")
-        && let Some(home) = dirs::home_dir()
-    {
-        return home.join(stripped);
+    if let Some(home) = dirs::home_dir() {
+        if s == "~" {
+            return home;
+        }
+        if let Some(stripped) = s.strip_prefix("~/") {
+            return home.join(stripped);
+        }
     }
     PathBuf::from(s)
 }
@@ -668,8 +673,10 @@ impl DocConfig {
     /// Priority 4: Built-in default (`~/.alcove/docs`) if the directory exists.
     fn roots_from_builtin_default() -> Option<Vec<ResolvedDocRoot>> {
         let fallback = default_docs_root();
-        // Use the same safety checks as resolve_single_root for consistency.
-        let canonical = fallback.canonicalize().unwrap_or(fallback);
+        // canonicalize() fails when the path doesn't exist — return None so the
+        // caller's priority chain stays clean.  Using `ok()?` also preserves the
+        // ResolvedDocRoot invariant that `path` is always in canonical form.
+        let canonical = fallback.canonicalize().ok()?;
         if is_blocked_system_path(&canonical) {
             eprintln!(
                 "[alcove] built-in default docs root points to blocked system path: {} — skipping",
@@ -1353,12 +1360,50 @@ mod tests {
 
     #[test]
     fn resolved_docs_roots_empty_when_nothing_configured() {
-        // Since we can't control whether ~/.alcove/docs exists in the test env,
-        // just verify no panic and a bounded return.
+        // The built-in default (~/.alcove/docs) may or may not exist in the
+        // test environment, so the result is 0 or 1 roots — both are valid.
         let cfg = DocConfig::default();
         let roots = cfg.resolved_docs_roots();
-        // Either 0 (no default dir) or 1 (default dir exists) — both valid.
         assert!(roots.len() <= 1);
+        // Whatever is returned must never be a raw uncanonicalized path.
+        for r in &roots {
+            assert!(
+                r.path.is_absolute(),
+                "resolved path must be absolute: {:?}",
+                r.path
+            );
+        }
+    }
+
+    #[test]
+    fn resolved_docs_roots_skips_nonexistent_docs_root_env() {
+        // When DOCS_ROOT points to a non-existent path it is skipped, and the
+        // chain falls through to the next source (legacy field, multi field, or
+        // built-in default). Verify that the invalid DOCS_ROOT path never appears
+        // in the returned roots — the chain must not pass through unchecked paths.
+        let prev = std::env::var("DOCS_ROOT").ok();
+        unsafe {
+            std::env::set_var("DOCS_ROOT", "/nonexistent-alcove-test-path-xyzqrs123");
+        }
+        let cfg = DocConfig::default();
+        let roots = cfg.resolved_docs_roots();
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("DOCS_ROOT", v) };
+        } else {
+            unsafe { std::env::remove_var("DOCS_ROOT") };
+        }
+        for r in &roots {
+            assert_ne!(
+                r.path.to_string_lossy().as_ref(),
+                "/nonexistent-alcove-test-path-xyzqrs123",
+                "invalid DOCS_ROOT path must never appear in resolved roots"
+            );
+            assert!(
+                r.path.is_absolute(),
+                "resolved path must be absolute: {:?}",
+                r.path
+            );
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,10 +344,62 @@ impl Default for MemoryConfig {
     }
 }
 
+/// A single entry in `docs_roots` — a named doc-root with an optional
+/// per-root embedding override.
+///
+/// ```toml
+/// [[docs_roots]]
+/// name = "oss"
+/// path = "~/.alcove/docs-oss"
+///
+/// [[docs_roots]]
+/// name = "work"
+/// path = "~/.alcove/docs-work"
+/// [docs_roots.embedding]
+/// model = "BGEM3"
+/// ```
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DocRootEntry {
+    /// Human-readable identifier shown in `list_projects` output.
+    pub name: String,
+    /// Filesystem path (tilde-expanded at runtime).
+    pub path: String,
+    /// Per-root embedding override.  Falls back to global `[embedding]` when absent.
+    #[cfg(feature = "embed-candle")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<EmbeddingConfig>,
+}
+
+/// A resolved `DocRootEntry` with the path expanded and validated.
+#[derive(Debug, Clone)]
+pub struct ResolvedDocRoot {
+    pub name: String,
+    pub path: PathBuf,
+    /// Per-root embedding override, if configured.
+    #[cfg(feature = "embed-candle")]
+    pub embedding: Option<EmbeddingConfig>,
+}
+
+impl DocRootEntry {
+    fn expand_path(&self) -> PathBuf {
+        if self.path.starts_with("~/") && let Some(home) = dirs::home_dir() {
+            return home.join(&self.path[2..]);
+        }
+        PathBuf::from(&self.path)
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DocConfig {
+    /// Legacy single doc-root path.  Still supported; takes precedence over
+    /// `docs_roots` when both are present (env var `DOCS_ROOT` takes precedence
+    /// over both).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs_root: Option<String>,
+    /// Multiple named doc-roots.  Ignored when `DOCS_ROOT` env var or `docs_root`
+    /// field is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docs_roots: Option<Vec<DocRootEntry>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub core: Option<CategoryConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -386,6 +438,7 @@ impl DocConfig {
     pub fn overlay(&self, base: &DocConfig) -> DocConfig {
         DocConfig {
             docs_root: self.docs_root.clone().or_else(|| base.docs_root.clone()),
+            docs_roots: self.docs_roots.clone().or_else(|| base.docs_roots.clone()),
             core: self.core.clone().or_else(|| base.core.clone()),
             team: self.team.clone().or_else(|| base.team.clone()),
             public: self.public.clone().or_else(|| base.public.clone()),
@@ -461,6 +514,67 @@ impl DocConfig {
             return Some(fallback);
         }
         None
+    }
+
+    /// Return all configured doc-roots as resolved paths.
+    ///
+    /// Priority (highest → lowest):
+    ///   1. `DOCS_ROOT` env var — single root named "default"
+    ///   2. `docs_root` field   — single root named "default"
+    ///   3. `docs_roots` field  — multiple named roots
+    ///   4. built-in default (`~/.alcove/docs`) if the directory exists
+    ///
+    /// Returns an empty Vec if no root is configured or discoverable.
+    pub fn resolved_docs_roots(&self) -> Vec<ResolvedDocRoot> {
+        // 1. DOCS_ROOT env var (handled in mcp.rs, but honour here too)
+        if let Ok(v) = std::env::var("DOCS_ROOT") {
+            let path = PathBuf::from(&v);
+            if !is_blocked_system_path(&path) {
+                return vec![ResolvedDocRoot {
+                    name: "default".into(),
+                    path,
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                }];
+            }
+        }
+        // 2. Legacy single docs_root field
+        if let Some(ref root) = self.docs_root {
+            let path = PathBuf::from(root);
+            return vec![ResolvedDocRoot {
+                name: "default".into(),
+                path,
+                #[cfg(feature = "embed-candle")]
+                embedding: None,
+            }];
+        }
+        // 3. Multi docs_roots
+        if let Some(ref entries) = self.docs_roots {
+            let roots: Vec<ResolvedDocRoot> = entries
+                .iter()
+                .map(|e| ResolvedDocRoot {
+                    name: e.name.clone(),
+                    path: e.expand_path(),
+                    #[cfg(feature = "embed-candle")]
+                    embedding: e.embedding.clone(),
+                })
+                .filter(|r| !is_blocked_system_path(&r.path))
+                .collect();
+            if !roots.is_empty() {
+                return roots;
+            }
+        }
+        // 4. Built-in default
+        let fallback = default_docs_root();
+        if fallback.is_dir() {
+            return vec![ResolvedDocRoot {
+                name: "default".into(),
+                path: fallback,
+                #[cfg(feature = "embed-candle")]
+                embedding: None,
+            }];
+        }
+        vec![]
     }
 
     #[cfg_attr(test, allow(dead_code))]
@@ -565,6 +679,7 @@ pub fn load_config() -> &'static DocConfig {
         }
         DocConfig {
             docs_root: None,
+            docs_roots: None,
             core: None,
             team: None,
             public: None,
@@ -1044,6 +1159,112 @@ mod tests {
         if let Some(ref p) = result {
             assert!(p.is_dir());
         }
+    }
+
+    // -- resolved_docs_roots --
+
+    #[test]
+    fn resolved_docs_roots_uses_legacy_docs_root() {
+        let cfg = DocConfig {
+            docs_root: Some("/tmp/legacy".into()),
+            ..DocConfig::default()
+        };
+        let roots = cfg.resolved_docs_roots();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].name, "default");
+        assert_eq!(roots[0].path, PathBuf::from("/tmp/legacy"));
+        #[cfg(feature = "embed-candle")]
+        assert!(roots[0].embedding.is_none());
+    }
+
+    #[test]
+    fn resolved_docs_roots_uses_docs_roots_vec() {
+        // docs_roots should be used when no DOCS_ROOT env var and no docs_root field.
+        // We set docs_root to a non-existent path so the legacy branch is skipped,
+        // which forces the docs_roots vec to be evaluated.
+        let cfg = DocConfig {
+            docs_root: Some("/tmp/nonexistent-alcove-test-root-xyz".into()),
+            docs_roots: Some(vec![
+                DocRootEntry {
+                    name: "oss".into(),
+                    path: "/tmp/oss".into(),
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                },
+                DocRootEntry {
+                    name: "work".into(),
+                    path: "/tmp/work".into(),
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                },
+            ]),
+            ..DocConfig::default()
+        };
+        // docs_root takes precedence over docs_roots — verify the field works at all.
+        let roots = cfg.resolved_docs_roots();
+        // docs_root field is set → that single root wins.
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].path, PathBuf::from("/tmp/nonexistent-alcove-test-root-xyz"));
+
+        // Now test docs_roots alone (no docs_root field).
+        let cfg2 = DocConfig {
+            docs_roots: Some(vec![
+                DocRootEntry {
+                    name: "oss".into(),
+                    path: "/tmp/oss".into(),
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                },
+                DocRootEntry {
+                    name: "work".into(),
+                    path: "/tmp/work".into(),
+                    #[cfg(feature = "embed-candle")]
+                    embedding: None,
+                },
+            ]),
+            ..DocConfig::default()
+        };
+        let roots2 = cfg2.resolved_docs_roots();
+        // Should have exactly 2 entries (docs_roots) — unless the default ~/.alcove/docs
+        // happens to exist on the test machine, in which case it falls through to fallback.
+        // Just assert the names are correct when len == 2.
+        if roots2.len() == 2 {
+            assert_eq!(roots2[0].name, "oss");
+            assert_eq!(roots2[1].name, "work");
+        } else {
+            // Default dir exists on this machine; can't isolate without temp dir tricks.
+            // Accept any non-zero count.
+            assert!(!roots2.is_empty());
+        }
+    }
+
+    #[test]
+    fn resolved_docs_roots_legacy_takes_precedence_over_vec() {
+        let cfg = DocConfig {
+            docs_root: Some("/tmp/legacy".into()),
+            docs_roots: Some(vec![DocRootEntry {
+                name: "oss".into(),
+                path: "/tmp/oss".into(),
+                #[cfg(feature = "embed-candle")]
+                embedding: None,
+            }]),
+            ..DocConfig::default()
+        };
+        // legacy docs_root takes precedence
+        let roots = cfg.resolved_docs_roots();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].path, PathBuf::from("/tmp/legacy"));
+    }
+
+    #[test]
+    fn resolved_docs_roots_empty_when_nothing_configured() {
+        // Ensure ~/.alcove/docs does NOT exist during this test.
+        // Since we can't control the env safely, just verify the method returns
+        // a consistent type — no panic.
+        let cfg = DocConfig::default();
+        let roots = cfg.resolved_docs_roots();
+        // Either 0 (no default dir) or 1 (default dir exists) — both valid.
+        assert!(roots.len() <= 1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -454,7 +454,7 @@ fn resolve_single_root(raw: &str, label: &str) -> Option<ResolvedDocRoot> {
 
 impl DocRootEntry {
     /// Expand `~` prefix and canonicalize the path.
-    /// Returns `None` if the path doesn't exist or points to a blocked system directory.
+    /// Returns `None` if the path doesn't exist, is not a directory, or points to a blocked system directory.
     fn expand_path(&self) -> Option<PathBuf> {
         let expanded = expand_tilde(&self.path);
         // Canonicalize to resolve symlinks / `..` traversal, then check safety.
@@ -473,6 +473,13 @@ impl DocRootEntry {
                 "[alcove] docs_roots entry '{}' points to blocked system path: {} — skipping",
                 self.name,
                 canonical.display()
+            );
+            return None;
+        }
+        if !canonical.is_dir() {
+            eprintln!(
+                "[alcove] docs_roots entry '{}' path '{}' is not a directory — skipping",
+                self.name, self.path
             );
             return None;
         }

--- a/src/launchd.rs
+++ b/src/launchd.rs
@@ -186,9 +186,10 @@ pub fn enable(kind: ServiceKind) -> Result<()> {
     }
     std::fs::create_dir_all(log_dir())?;
 
-    // Unload first if already registered
+    // Unload first if already registered, then wait for port release.
     if is_loaded(kind) {
-        let _ = launchctl(&["unload", &plist.to_string_lossy()]);
+        launchctl(&["unload", &plist.to_string_lossy()])?;
+        std::thread::sleep(std::time::Duration::from_millis(300));
     }
 
     // Write plist

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,16 +11,10 @@ use crate::tools;
 // Multi-root helpers
 // ---------------------------------------------------------------------------
 
-/// Check whether the current working directory is physically inside `root`.
-/// Uses `canonicalize` to resolve symlinks before comparison.
-fn is_cwd_inside_root(root: &std::path::Path) -> bool {
-    let Ok(cwd) = std::env::current_dir() else {
-        return false;
-    };
+/// Check whether `canonical_cwd` is physically inside the canonical form of `root`.
+/// Caller must pass an already-canonicalized CWD to avoid repeated syscall overhead.
+fn is_cwd_inside_root(root: &std::path::Path, canonical_cwd: &std::path::Path) -> bool {
     let Ok(canonical_root) = root.canonicalize() else {
-        return false;
-    };
-    let Ok(canonical_cwd) = cwd.canonicalize() else {
         return false;
     };
     canonical_cwd.starts_with(&canonical_root)
@@ -38,12 +32,19 @@ fn resolve_project_multi(
     all_roots: &[ResolvedDocRoot],
     id: &Option<Value>,
 ) -> Result<(std::path::PathBuf, tools::ResolvedProject), RpcResponse> {
+    // Pre-compute canonical CWD once to avoid repeated syscall overhead per root.
+    let canonical_cwd = std::env::current_dir()
+        .ok()
+        .and_then(|c| c.canonicalize().ok());
     let mut found: Option<(std::path::PathBuf, tools::ResolvedProject)> = None;
     let mut ambiguous_env = false;
     for root in all_roots {
         if let Some(r) = tools::resolve_project(&root.path) {
             if r.detected_via == "cwd" {
-                if !is_cwd_inside_root(&root.path) {
+                let cwd_valid = canonical_cwd
+                    .as_ref()
+                    .is_some_and(|cc| is_cwd_inside_root(&root.path, cc));
+                if !cwd_valid {
                     continue; // Name matched but CWD is under a different root
                 }
                 found = Some((root.path.clone(), r));
@@ -859,6 +860,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         };
     }
     if call.name == "rebuild_index" {
+        let root_count = all_roots.len();
         let roots_clone: Vec<_> = all_roots.iter().map(|r| r.path.clone()).collect();
         std::thread::spawn(move || {
             use rayon::prelude::*;
@@ -881,7 +883,12 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         });
         return ok!(json!({
             "status": "started",
-            "message": "Index build started in background. Search will use the updated index once complete."
+            "root_count": root_count,
+            "message": format!(
+                "Index build started for {} root(s) in background. \
+                 Search will use the updated index once complete.",
+                root_count
+            )
         }));
     }
     if call.name == "check_doc_changes" {
@@ -964,6 +971,16 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     merged_matches.extend(arr.clone());
                 }
                 truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
+            }
+            // Sort by score descending, then truncate to limit.
+            merged_matches.sort_by(|a, b| {
+                let sa = a["score"].as_f64().unwrap_or(0.0);
+                let sb = b["score"].as_f64().unwrap_or(0.0);
+                sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            if merged_matches.len() > limit {
+                truncated = true;
+                merged_matches.truncate(limit);
             }
             return ok!(json!({
                 "query": query,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -731,19 +731,35 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         );
     }
     // Primary root: first entry (DOCS_ROOT env var, docs_root field, or first docs_roots entry).
-    // NOTE: lint_project, promote_document, and check_doc_changes operate on this root only.
-    // In multi-root configs these tools always target the highest-priority root.
+    // NOTE: lint_project, promote_document, check_doc_changes, and init_project operate on
+    // this root only. In multi-root configs these tools always target the highest-priority root.
     let primary_root = all_roots[0].path.clone();
+    let primary_root_name = all_roots[0].name.clone();
+    let multi_root = all_roots.len() > 1;
+
+    // Inject `"root"` into a tool response when multiple roots are configured so
+    // callers can tell which root was targeted.
+    macro_rules! ok_with_root {
+        ($val:expr) => {{
+            let mut v = $val;
+            if multi_root {
+                if let Some(obj) = v.as_object_mut() {
+                    obj.insert("root".to_owned(), json!(primary_root_name));
+                }
+            }
+            ok!(v)
+        }};
+    }
 
     if call.name == "lint_project" {
         return match tools::tool_lint_project(&primary_root, call.arguments) {
-            Ok(v) => ok!(v),
+            Ok(v) => ok_with_root!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
     }
     if call.name == "promote_document" {
         return match tools::tool_promote_document(&primary_root, call.arguments) {
-            Ok(v) => ok!(v),
+            Ok(v) => ok_with_root!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
     }
@@ -855,7 +871,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         return match tools::tool_init_project(&primary_root, call.arguments) {
             Ok(v) => {
                 let _ = crate::index::build_index(&primary_root);
-                ok!(v)
+                ok_with_root!(v)
             }
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
@@ -888,14 +904,15 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             "message": format!(
                 "Index build started for {} root(s) in background. \
                  Search will use the updated index once complete. \
-                 Build failures (if any) are logged to stderr.",
+                 Any build failures are logged to the server stderr — \
+                 check the alcove process output if search results look stale.",
                 root_count
             )
         }));
     }
     if call.name == "check_doc_changes" {
         return match tools::tool_check_doc_changes(&primary_root, call.arguments) {
-            Ok(v) => ok!(v),
+            Ok(v) => ok_with_root!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -808,8 +808,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         if is_global {
             // Multi-root global search: try indexed search across all roots in parallel,
             // fall back to grep-based global search on the primary root.
-            if !force_grep && let Ok(v) =
-                tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
+            if !force_grep
+                && let Ok(v) =
+                    tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
             {
                 let matches = v["matches"].as_array();
                 if matches.is_some_and(|m| !m.is_empty()) {
@@ -819,9 +820,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             // Grep fallback: try each root until we get results.
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    let has_matches = v["matches"]
-                        .as_array()
-                        .is_some_and(|m| !m.is_empty());
+                    let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
                     if has_matches {
                         return ok!(v);
                     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,13 +11,13 @@ use crate::tools;
 // Multi-root helpers
 // ---------------------------------------------------------------------------
 
-/// Check whether `canonical_cwd` is physically inside the canonical form of `root`.
-/// Caller must pass an already-canonicalized CWD to avoid repeated syscall overhead.
+/// Check whether `canonical_cwd` is physically inside `root`.
+///
+/// Both `root` and `canonical_cwd` must already be canonicalized.
+/// `ResolvedDocRoot.path` is always canonical (set via `canonicalize()` in config),
+/// so no additional syscall is needed here.
 fn is_cwd_inside_root(root: &std::path::Path, canonical_cwd: &std::path::Path) -> bool {
-    let Ok(canonical_root) = root.canonicalize() else {
-        return false;
-    };
-    canonical_cwd.starts_with(&canonical_root)
+    canonical_cwd.starts_with(root)
 }
 
 /// Resolve the active project across all configured doc-roots.
@@ -965,12 +965,10 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                 .map(|root| tools::tool_search_global(&root.path, args_clone.clone()).ok())
                 .collect();
             let mut merged_matches: Vec<Value> = Vec::new();
-            let mut truncated = false;
             for v in root_results.into_iter().flatten() {
                 if let Some(arr) = v["matches"].as_array() {
                     merged_matches.extend(arr.clone());
                 }
-                truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
             }
             // Sort by score descending, then truncate to limit.
             merged_matches.sort_by(|a, b| {
@@ -978,10 +976,8 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                 let sb = b["score"].as_f64().unwrap_or(0.0);
                 sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
             });
-            if merged_matches.len() > limit {
-                truncated = true;
-                merged_matches.truncate(limit);
-            }
+            let truncated = merged_matches.len() > limit;
+            merged_matches.truncate(limit);
             return ok!(json!({
                 "query": query,
                 "matches": merged_matches,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -817,7 +817,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     return ok!(v);
                 }
             }
-            // Grep fallback: try each root until we get results.
+            // Grep fallback: return results from the first root that has matches.
+            // Full cross-root grep merge is not implemented — use indexed search
+            // for comprehensive multi-root results.
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
                     let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
@@ -850,10 +852,22 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
 
     // All other tools require a resolved project.
     // For multi-root: find the root whose CWD match resolves the project.
+    // When detected via CWD, verify the CWD is actually under that root to
+    // prevent selecting the wrong root when multiple roots share a project name.
     let (docs_root, resolved) = {
         let mut found = None;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
+                if r.detected_via == "cwd" {
+                    // Cross-validate: CWD must be under this root's path
+                    if let Ok(cwd) = std::env::current_dir()
+                        && let Ok(canonical_root) = root.path.canonicalize()
+                        && let Ok(canonical_cwd) = cwd.canonicalize()
+                        && !canonical_cwd.starts_with(&canonical_root)
+                    {
+                        continue; // Name matched but CWD is under a different root
+                    }
+                }
                 found = Some((root.path.clone(), r));
                 break;
             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -866,15 +866,10 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
     // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
     // multiple roots (ambiguity).
     let (docs_root, resolved) = {
-        let mut found = None;
+        let mut found: Option<(std::path::PathBuf, _)> = None;
         let mut ambiguous_env = false;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
-                if found.is_some() && r.detected_via == "env" {
-                    // Same project name resolved in another root — ambiguity.
-                    ambiguous_env = true;
-                    break;
-                }
                 if r.detected_via == "cwd" {
                     // Cross-validate: CWD must be under this root's path
                     if let Ok(cwd) = std::env::current_dir()
@@ -884,13 +879,16 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     {
                         continue; // Name matched but CWD is under a different root
                     }
-                }
-                let is_cwd = r.detected_via == "cwd";
-                found = Some((root.path.clone(), r));
-                // For CWD detection, stop at first validated match.
-                // For env detection, continue scanning to detect ambiguity.
-                if is_cwd {
-                    break;
+                    found = Some((root.path.clone(), r));
+                    break; // CWD detection is unambiguous — stop at first validated match
+                } else {
+                    // env detection: record first match, flag if a second match appears
+                    if found.is_some() {
+                        ambiguous_env = true;
+                        break;
+                    }
+                    found = Some((root.path.clone(), r));
+                    // continue scanning remaining roots to detect ambiguity
                 }
             }
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -949,16 +949,21 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     return ok!(v);
                 }
             }
-            // Grep fallback: merge results from all roots for comprehensive coverage.
+            // Grep fallback: merge results from all roots in parallel for
+            // comprehensive coverage.
+            use rayon::prelude::*;
+            let args_clone = call.arguments.clone();
+            let root_results: Vec<Option<Value>> = all_roots
+                .par_iter()
+                .map(|root| tools::tool_search_global(&root.path, args_clone.clone()).ok())
+                .collect();
             let mut merged_matches: Vec<Value> = Vec::new();
             let mut truncated = false;
-            for root in &all_roots {
-                if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    if let Some(arr) = v["matches"].as_array() {
-                        merged_matches.extend(arr.clone());
-                    }
-                    truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
+            for v in root_results.into_iter().flatten() {
+                if let Some(arr) = v["matches"].as_array() {
+                    merged_matches.extend(arr.clone());
                 }
+                truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
             }
             return ok!(json!({
                 "query": query,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -765,9 +765,10 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
     if call.name == "rebuild_index" {
         let roots_clone: Vec<_> = all_roots.iter().map(|r| r.path.clone()).collect();
         std::thread::spawn(move || {
-            for root in &roots_clone {
+            use rayon::prelude::*;
+            roots_clone.par_iter().for_each(|root| {
                 let _ = crate::index::build_index(root);
-            }
+            });
         });
         return ok!(json!({
             "status": "started",
@@ -817,18 +818,23 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     return ok!(v);
                 }
             }
-            // Grep fallback: return results from the first root that has matches.
-            // Full cross-root grep merge is not implemented — use indexed search
-            // for comprehensive multi-root results.
+            // Grep fallback: merge results from all roots for comprehensive coverage.
+            let mut merged_matches: Vec<Value> = Vec::new();
+            let mut truncated = false;
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
-                    if has_matches {
-                        return ok!(v);
+                    if let Some(arr) = v["matches"].as_array() {
+                        merged_matches.extend(arr.clone());
                     }
+                    truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
                 }
             }
-            return ok!(json!({"query": query, "matches": [], "truncated": false, "mode": "grep"}));
+            return ok!(json!({
+                "query": query,
+                "matches": merged_matches,
+                "truncated": truncated,
+                "mode": "grep",
+            }));
         }
 
         if !force_grep {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3,9 +3,105 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::config::{is_reserved_dir_name, load_config};
+use crate::config::{ResolvedDocRoot, is_reserved_dir_name, load_config};
 use crate::telemetry::{FailureClass, ResultSizeBucket, Telemetry, Tool};
 use crate::tools;
+
+// ---------------------------------------------------------------------------
+// Multi-root helpers
+// ---------------------------------------------------------------------------
+
+/// Check whether the current working directory is physically inside `root`.
+/// Uses `canonicalize` to resolve symlinks before comparison.
+fn is_cwd_inside_root(root: &std::path::Path) -> bool {
+    let Ok(cwd) = std::env::current_dir() else {
+        return false;
+    };
+    let Ok(canonical_root) = root.canonicalize() else {
+        return false;
+    };
+    let Ok(canonical_cwd) = cwd.canonicalize() else {
+        return false;
+    };
+    canonical_cwd.starts_with(&canonical_root)
+}
+
+/// Resolve the active project across all configured doc-roots.
+///
+/// For CWD-based detection, cross-validates that the CWD is actually under
+/// the matched root. For env-based detection (`MCP_PROJECT_NAME`), warns
+/// if the project name exists in multiple roots (ambiguity).
+///
+/// Returns `(docs_root, resolved_project)` on success, or an `RpcResponse`
+/// error if no project can be resolved.
+fn resolve_project_multi(
+    all_roots: &[ResolvedDocRoot],
+    id: &Option<Value>,
+) -> Result<(std::path::PathBuf, tools::ResolvedProject), RpcResponse> {
+    let mut found: Option<(std::path::PathBuf, tools::ResolvedProject)> = None;
+    let mut ambiguous_env = false;
+    for root in all_roots {
+        if let Some(r) = tools::resolve_project(&root.path) {
+            if r.detected_via == "cwd" {
+                if !is_cwd_inside_root(&root.path) {
+                    continue; // Name matched but CWD is under a different root
+                }
+                found = Some((root.path.clone(), r));
+                break; // CWD detection is unambiguous — stop at first validated match
+            } else {
+                // env detection: record first match, flag if a second match appears
+                if found.is_some() {
+                    ambiguous_env = true;
+                    break;
+                }
+                found = Some((root.path.clone(), r));
+                // continue scanning remaining roots to detect ambiguity
+            }
+        }
+    }
+    if ambiguous_env {
+        eprintln!(
+            "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — \
+             using the first match. Consider running from the project directory instead."
+        );
+    }
+    match found {
+        Some(pair) => Ok(pair),
+        None => {
+            let available: Vec<String> = all_roots
+                .iter()
+                .flat_map(|root| {
+                    std::fs::read_dir(&root.path)
+                        .ok()
+                        .map(|rd| {
+                            rd.filter_map(std::result::Result::ok)
+                                .filter(|e| e.path().is_dir())
+                                .filter_map(|e| {
+                                    let name = e.file_name().to_string_lossy().to_string();
+                                    if is_reserved_dir_name(&name) {
+                                        None
+                                    } else {
+                                        Some(name)
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                })
+                .collect();
+            Err(RpcResponse::err(
+                id.clone(),
+                -32001,
+                format!(
+                    "Could not detect project. CWD does not match any project in DOCS_ROOT. \
+                     Available projects: [{}]. \
+                     Set MCP_PROJECT_NAME env var or run from within a project directory.",
+                    available.join(", ")
+                ),
+            ))
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // JSON-RPC 2.0 types
@@ -769,9 +865,19 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             // build_index is safe to call concurrently on distinct roots:
             // all writes are scoped to `root/.alcove/index/` and a per-root
             // file lock prevents concurrent builds on the same root.
-            roots_clone.par_iter().for_each(|root| {
-                let _ = crate::index::build_index(root);
-            });
+            let failures: Vec<_> = roots_clone
+                .par_iter()
+                .filter_map(|root| {
+                    crate::index::build_index(root)
+                        .err()
+                        .map(|e| (root.display().to_string(), e))
+                })
+                .collect();
+            if !failures.is_empty() {
+                for (path, err) in &failures {
+                    eprintln!("[alcove] index build failed for {}: {}", path, err);
+                }
+            }
         });
         return ok!(json!({
             "status": "started",
@@ -784,6 +890,28 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
     }
+
+    // Resolve project early — needed by per-project search and all other tools.
+    // Skip for global search which doesn't need a specific project.
+    let needs_project = call.name != "search_project_docs"
+        || call.arguments.get("scope").and_then(|v| v.as_str()) != Some("global");
+
+    let (docs_root, resolved) = if needs_project {
+        match resolve_project_multi(&all_roots, &id) {
+            Ok(pair) => pair,
+            Err(resp) => return resp,
+        }
+    } else {
+        // Placeholder — won't be used for global search (returns early).
+        (
+            all_roots[0].path.clone(),
+            tools::ResolvedProject {
+                name: String::new(),
+                detected_via: "",
+                repo_path: None,
+            },
+        )
+    };
 
     // Search: auto mode selection — ranked (BM25) if index available, grep fallback
     if call.name == "search_project_docs" {
@@ -811,7 +939,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
 
         if is_global {
             // Multi-root global search: try indexed search across all roots in parallel,
-            // fall back to grep-based global search on the primary root.
+            // fall back to grep-based global search across all roots.
             if !force_grep
                 && let Ok(v) =
                     tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
@@ -840,99 +968,20 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             }));
         }
 
+        // Per-project search: use already-resolved docs_root and resolved.
         if !force_grep {
             let index_dir = docs_root.join(".alcove").join("index");
-            if index_dir.exists() || crate::index::ensure_index_fresh(&docs_root) {
-                let project_filter = tools::resolve_project(&docs_root).map(|r| r.name);
-                if let Ok(v) = crate::index::search_indexed(
-                    &docs_root,
-                    query,
-                    limit,
-                    project_filter.as_deref(),
-                ) {
-                    let matches = v["matches"].as_array();
-                    if matches.is_some_and(|m| !m.is_empty()) {
-                        return ok!(v);
-                    }
+            if (index_dir.exists() || crate::index::ensure_index_fresh(&docs_root))
+                && let Ok(v) =
+                    crate::index::search_indexed(&docs_root, query, limit, Some(&resolved.name))
+            {
+                let matches = v["matches"].as_array();
+                if matches.is_some_and(|m| !m.is_empty()) {
+                    return ok!(v);
                 }
             }
         }
     }
-
-    // All other tools require a resolved project.
-    // For multi-root: find the root whose CWD match resolves the project.
-    // When detected via CWD, verify the CWD is actually under that root to
-    // prevent selecting the wrong root when multiple roots share a project name.
-    // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
-    // multiple roots (ambiguity).
-    let (docs_root, resolved) = {
-        let mut found: Option<(std::path::PathBuf, _)> = None;
-        let mut ambiguous_env = false;
-        for root in &all_roots {
-            if let Some(r) = tools::resolve_project(&root.path) {
-                if r.detected_via == "cwd" {
-                    // Cross-validate: CWD must be under this root's path
-                    if let Ok(cwd) = std::env::current_dir()
-                        && let Ok(canonical_root) = root.path.canonicalize()
-                        && let Ok(canonical_cwd) = cwd.canonicalize()
-                        && !canonical_cwd.starts_with(&canonical_root)
-                    {
-                        continue; // Name matched but CWD is under a different root
-                    }
-                    found = Some((root.path.clone(), r));
-                    break; // CWD detection is unambiguous — stop at first validated match
-                } else {
-                    // env detection: record first match, flag if a second match appears
-                    if found.is_some() {
-                        ambiguous_env = true;
-                        break;
-                    }
-                    found = Some((root.path.clone(), r));
-                    // continue scanning remaining roots to detect ambiguity
-                }
-            }
-        }
-        if ambiguous_env {
-            eprintln!(
-                "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — using the first match. Consider running from the project directory instead."
-            );
-        }
-        match found {
-            Some(pair) => pair,
-            None => {
-                let available: Vec<String> = all_roots
-                    .iter()
-                    .flat_map(|root| {
-                        std::fs::read_dir(&root.path)
-                            .ok()
-                            .map(|rd| {
-                                rd.filter_map(std::result::Result::ok)
-                                    .filter(|e| e.path().is_dir())
-                                    .filter_map(|e| {
-                                        let name = e.file_name().to_string_lossy().to_string();
-                                        if is_reserved_dir_name(&name) {
-                                            None
-                                        } else {
-                                            Some(name)
-                                        }
-                                    })
-                                    .collect::<Vec<_>>()
-                            })
-                            .unwrap_or_default()
-                    })
-                    .collect();
-                return err!(
-                    -32001,
-                    format!(
-                        "Could not detect project. CWD does not match any project in DOCS_ROOT. \
-                         Available projects: [{}]. \
-                         Set MCP_PROJECT_NAME env var or run from within a project directory.",
-                        available.join(", ")
-                    )
-                );
-            }
-        }
-    };
 
     let project_root = docs_root.join(&resolved.name);
     let repo_path = resolved.repo_path.as_deref();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -731,17 +731,18 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         );
     }
     // Primary root: first entry (DOCS_ROOT env var, docs_root field, or first docs_roots entry).
-    let docs_root = all_roots[0].path.clone();
+    // NOTE: lint_project, promote_document, and check_doc_changes operate on this root only.
+    // In multi-root configs these tools always target the highest-priority root.
+    let primary_root = all_roots[0].path.clone();
 
-    // lint_project and promote_document operate on docs_root directly
     if call.name == "lint_project" {
-        return match tools::tool_lint_project(&docs_root, call.arguments) {
+        return match tools::tool_lint_project(&primary_root, call.arguments) {
             Ok(v) => ok!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
     }
     if call.name == "promote_document" {
-        return match tools::tool_promote_document(&docs_root, call.arguments) {
+        return match tools::tool_promote_document(&primary_root, call.arguments) {
             Ok(v) => ok!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
@@ -851,9 +852,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         };
     }
     if call.name == "init_project" {
-        return match tools::tool_init_project(&docs_root, call.arguments) {
+        return match tools::tool_init_project(&primary_root, call.arguments) {
             Ok(v) => {
-                let _ = crate::index::build_index(&docs_root);
+                let _ = crate::index::build_index(&primary_root);
                 ok!(v)
             }
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
@@ -893,7 +894,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         }));
     }
     if call.name == "check_doc_changes" {
-        return match tools::tool_check_doc_changes(&docs_root, call.arguments) {
+        return match tools::tool_check_doc_changes(&primary_root, call.arguments) {
             Ok(v) => ok!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
@@ -1797,5 +1798,106 @@ mod tests {
         assert!(text.contains("alpha"), "should list alpha vault");
         assert!(text.contains("beta"), "should list beta vault");
         assert!(text.contains("doc_count"), "should contain doc_count field");
+    }
+
+    // -- resolve_project_multi --
+
+    /// Returns a `ResolvedDocRoot` with the given name pointing at `path`.
+    fn make_root(name: &str, path: std::path::PathBuf) -> crate::config::ResolvedDocRoot {
+        let mut r = crate::config::ResolvedDocRoot::new_default(path);
+        r.name = name.into();
+        r
+    }
+
+    /// When `MCP_PROJECT_NAME` matches a project in two roots, the function
+    /// must return the first root and not panic.
+    #[test]
+    #[serial]
+    fn resolve_project_multi_env_ambiguity_uses_first_root() {
+        let root1 = test_tempdir();
+        let root2 = test_tempdir();
+        std::fs::create_dir(root1.path().join("shared")).unwrap();
+        std::fs::create_dir(root2.path().join("shared")).unwrap();
+
+        let prev = std::env::var("MCP_PROJECT_NAME").ok();
+        unsafe { std::env::set_var("MCP_PROJECT_NAME", "shared") };
+
+        let r1 = make_root("oss", root1.path().canonicalize().unwrap());
+        let r2 = make_root("work", root2.path().canonicalize().unwrap());
+        let result = resolve_project_multi(&[r1, r2], &None);
+
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("MCP_PROJECT_NAME", v) };
+        } else {
+            unsafe { std::env::remove_var("MCP_PROJECT_NAME") };
+        }
+
+        let (path, _project) = result.expect("should resolve to first matching root");
+        assert_eq!(
+            path,
+            root1.path().canonicalize().unwrap(),
+            "first root must win on env ambiguity"
+        );
+    }
+
+    /// When `MCP_PROJECT_NAME` is unset and CWD name matches a project inside a
+    /// root but CWD is NOT physically under that root, the match must be rejected.
+    #[test]
+    #[serial]
+    fn resolve_project_multi_cwd_mismatch_skips_non_containing_root() {
+        let root = test_tempdir();
+
+        // Name the project after the last component of CWD — resolve_project()
+        // will detect it via CWD path-walk, but is_cwd_inside_root() must reject
+        // it because CWD is not inside `root` (which is a tempdir elsewhere).
+        let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+        let cwd_leaf = cwd.file_name().unwrap().to_string_lossy().to_string();
+        std::fs::create_dir(root.path().join(&cwd_leaf)).unwrap();
+
+        let prev = std::env::var("MCP_PROJECT_NAME").ok();
+        unsafe { std::env::remove_var("MCP_PROJECT_NAME") };
+
+        let resolved_root = make_root("default", root.path().canonicalize().unwrap());
+        let result = resolve_project_multi(&[resolved_root], &None);
+
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("MCP_PROJECT_NAME", v) };
+        }
+
+        assert!(
+            result.is_err(),
+            "CWD name match with root mismatch must not resolve; got {:?}",
+            result.ok().map(|(p, r)| (p, r.name))
+        );
+    }
+
+    /// When no root contains a project matching either env or CWD, return an Err
+    /// whose message lists available projects.
+    #[test]
+    #[serial]
+    fn resolve_project_multi_returns_err_with_available_list() {
+        let root = test_tempdir();
+        std::fs::create_dir(root.path().join("alpha")).unwrap();
+        std::fs::create_dir(root.path().join("beta")).unwrap();
+
+        let prev = std::env::var("MCP_PROJECT_NAME").ok();
+        unsafe { std::env::remove_var("MCP_PROJECT_NAME") };
+
+        // Use a project name that cannot possibly match any CWD component.
+        // We don't set MCP_PROJECT_NAME, so only CWD detection runs — and CWD
+        // contains no component named "alpha" or "beta" in normal dev environments.
+        let resolved_root = make_root("default", root.path().canonicalize().unwrap());
+        let result = resolve_project_multi(&[resolved_root], &None);
+
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("MCP_PROJECT_NAME", v) };
+        }
+
+        assert!(result.is_err(), "should return Err when no project matches");
+        let msg = result.unwrap_err().error.unwrap().message;
+        assert!(
+            msg.contains("alpha") || msg.contains("beta"),
+            "error message must list available projects, got: {msg}"
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -883,7 +883,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         });
         return ok!(json!({
             "status": "started",
-            "root_count": root_count,
+            "roots_total": root_count,
             "message": format!(
                 "Index build started for {} root(s) in background. \
                  Search will use the updated index once complete. \
@@ -899,53 +899,30 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         };
     }
 
-    // Resolve project early — needed by per-project search and all other tools.
-    // Skip for global search which doesn't need a specific project.
-    let needs_project = call.name != "search_project_docs"
-        || call.arguments.get("scope").and_then(|v| v.as_str()) != Some("global");
-
-    let (docs_root, resolved) = if needs_project {
-        match resolve_project_multi(&all_roots, &id) {
-            Ok(pair) => pair,
-            Err(resp) => return resp,
-        }
-    } else {
-        // Placeholder — won't be used for global search (returns early).
-        (
-            all_roots[0].path.clone(),
-            tools::ResolvedProject {
-                name: String::new(),
-                detected_via: "",
-                repo_path: None,
-            },
-        )
-    };
-
-    // Search: auto mode selection — ranked (BM25) if index available, grep fallback
+    // Global search doesn't need a resolved project — handle it early and return.
     if call.name == "search_project_docs" {
         let scope = call
             .arguments
             .get("scope")
             .and_then(|v| v.as_str())
             .unwrap_or("project");
-        let mode_override = call.arguments.get("mode").and_then(|v| v.as_str());
-
         let is_global = scope == "global";
-        let limit = call
-            .arguments
-            .get("limit")
-            .and_then(serde_json::Value::as_u64)
-            .map(|v| usize::try_from(v).unwrap_or(usize::MAX).clamp(1, 200))
-            .unwrap_or(20);
-        let query = call
-            .arguments
-            .get("query")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        let force_grep = mode_override == Some("grep");
 
         if is_global {
+            let mode_override = call.arguments.get("mode").and_then(|v| v.as_str());
+            let limit = call
+                .arguments
+                .get("limit")
+                .and_then(serde_json::Value::as_u64)
+                .map(|v| usize::try_from(v).unwrap_or(usize::MAX).clamp(1, 200))
+                .unwrap_or(20);
+            let query = call
+                .arguments
+                .get("query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let force_grep = mode_override == Some("grep");
+
             // Multi-root global search: try indexed search across all roots in parallel,
             // fall back to grep-based global search across all roots.
             if !force_grep
@@ -994,8 +971,30 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                 "mode": "grep",
             }));
         }
+    }
 
-        // Per-project search: use already-resolved docs_root and resolved.
+    // All remaining tools require a resolved project.
+    let (docs_root, resolved) = match resolve_project_multi(&all_roots, &id) {
+        Ok(pair) => pair,
+        Err(resp) => return resp,
+    };
+
+    // Per-project search (non-global).
+    if call.name == "search_project_docs" {
+        let mode_override = call.arguments.get("mode").and_then(|v| v.as_str());
+        let limit = call
+            .arguments
+            .get("limit")
+            .and_then(serde_json::Value::as_u64)
+            .map(|v| usize::try_from(v).unwrap_or(usize::MAX).clamp(1, 200))
+            .unwrap_or(20);
+        let query = call
+            .arguments
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let force_grep = mode_override == Some("grep");
+
         if !force_grep {
             let index_dir = docs_root.join(".alcove").join("index");
             if (index_dir.exists() || crate::index::ensure_index_fresh(&docs_root))

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -828,7 +828,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     }
                 }
             }
-            return ok!(json!({"query": "", "matches": [], "truncated": false, "mode": "grep"}));
+            return ok!(json!({"query": query, "matches": [], "truncated": false, "mode": "grep"}));
         }
 
         if !force_grep {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -766,6 +766,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         let roots_clone: Vec<_> = all_roots.iter().map(|r| r.path.clone()).collect();
         std::thread::spawn(move || {
             use rayon::prelude::*;
+            // build_index is safe to call concurrently on distinct roots:
+            // all writes are scoped to `root/.alcove/index/` and a per-root
+            // file lock prevents concurrent builds on the same root.
             roots_clone.par_iter().for_each(|root| {
                 let _ = crate::index::build_index(root);
             });

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -854,10 +854,18 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
     // For multi-root: find the root whose CWD match resolves the project.
     // When detected via CWD, verify the CWD is actually under that root to
     // prevent selecting the wrong root when multiple roots share a project name.
+    // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
+    // multiple roots (ambiguity).
     let (docs_root, resolved) = {
         let mut found = None;
+        let mut ambiguous_env = false;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
+                if found.is_some() && r.detected_via == "env" {
+                    // Same project name resolved in another root — ambiguity.
+                    ambiguous_env = true;
+                    break;
+                }
                 if r.detected_via == "cwd" {
                     // Cross-validate: CWD must be under this root's path
                     if let Ok(cwd) = std::env::current_dir()
@@ -868,9 +876,19 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                         continue; // Name matched but CWD is under a different root
                     }
                 }
+                let is_cwd = r.detected_via == "cwd";
                 found = Some((root.path.clone(), r));
-                break;
+                // For CWD detection, stop at first validated match.
+                // For env detection, continue scanning to detect ambiguity.
+                if is_cwd {
+                    break;
+                }
             }
+        }
+        if ambiguous_env {
+            eprintln!(
+                "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — using the first match. Consider running from the project directory instead."
+            );
         }
         match found {
             Some(pair) => pair,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -37,7 +37,7 @@ fn resolve_project_multi(
         .ok()
         .and_then(|c| c.canonicalize().ok());
     let mut found: Option<(std::path::PathBuf, tools::ResolvedProject)> = None;
-    let mut ambiguous_env = false;
+    let mut env_match_count: usize = 0;
     for root in all_roots {
         if let Some(r) = tools::resolve_project(&root.path) {
             if r.detected_via == "cwd" {
@@ -50,20 +50,20 @@ fn resolve_project_multi(
                 found = Some((root.path.clone(), r));
                 break; // CWD detection is unambiguous — stop at first validated match
             } else {
-                // env detection: record first match, flag if a second match appears
-                if found.is_some() {
-                    ambiguous_env = true;
-                    break;
+                // env detection: scan all roots to get the total match count
+                // before emitting a warning, so the message includes the full count.
+                env_match_count += 1;
+                if found.is_none() {
+                    found = Some((root.path.clone(), r));
                 }
-                found = Some((root.path.clone(), r));
-                // continue scanning remaining roots to detect ambiguity
             }
         }
     }
-    if ambiguous_env {
+    if env_match_count > 1 {
         eprintln!(
-            "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — \
-             using the first match. Consider running from the project directory instead."
+            "[alcove] WARNING: MCP_PROJECT_NAME matches projects in {} roots — \
+             using the first match. Consider running from the project directory instead.",
+            env_match_count
         );
     }
     match found {
@@ -731,8 +731,13 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         );
     }
     // Primary root: first entry (DOCS_ROOT env var, docs_root field, or first docs_roots entry).
-    // NOTE: lint_project, promote_document, check_doc_changes, and init_project operate on
-    // this root only. In multi-root configs these tools always target the highest-priority root.
+    //
+    // Multi-root routing limitation: lint_project, promote_document, check_doc_changes,
+    // and init_project always operate on primary_root only, regardless of how many roots
+    // are configured.  They do not accept a `root` selector argument.  The `ok_with_root!`
+    // macro injects `"root": primary_root_name` into their responses so callers can see
+    // which root was targeted, but no routing to a non-primary root is possible today.
+    // TODO: add a `root` argument to these tools if per-root targeting becomes needed.
     let primary_root = all_roots[0].path.clone();
     let primary_root_name = all_roots[0].name.clone();
     let multi_root = all_roots.len() > 1;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,10 +1,9 @@
-use std::path::PathBuf;
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::config::{is_blocked_system_path, is_reserved_dir_name, load_config};
+use crate::config::{is_reserved_dir_name, load_config};
 use crate::telemetry::{FailureClass, ResultSizeBucket, Telemetry, Tool};
 use crate::tools;
 
@@ -625,26 +624,17 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         }};
     }
 
-    let docs_root = match std::env::var("DOCS_ROOT") {
-        Ok(v) => {
-            let path = PathBuf::from(&v);
-            if is_blocked_system_path(&path) {
-                return err!(
-                    -32000,
-                    "DOCS_ROOT points to a restricted system directory.".into()
-                );
-            }
-            path
-        }
-        Err(_) => {
-            match load_config().docs_root() {
-                Some(p) if p.is_dir() => p,
-                _ => {
-                    return err!(-32000, "DOCS_ROOT environment variable is not set and config.toml has no docs_root.".into());
-                }
-            }
-        }
-    };
+    // Resolve all configured doc-roots (multi-root aware).
+    // DOCS_ROOT env var → single legacy root; otherwise use config.
+    let all_roots = load_config().resolved_docs_roots();
+    if all_roots.is_empty() {
+        return err!(
+            -32000,
+            "No doc-root configured. Set DOCS_ROOT env var, or add docs_root / [[docs_roots]] to config.toml.".into()
+        );
+    }
+    // Primary root: first entry (DOCS_ROOT env var, docs_root field, or first docs_roots entry).
+    let docs_root = all_roots[0].path.clone();
 
     // lint_project and promote_document operate on docs_root directly
     if call.name == "lint_project" {
@@ -758,7 +748,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
 
     // list_projects and init_project don't need a resolved project
     if call.name == "list_projects" {
-        return match tools::tool_list_projects(&docs_root) {
+        return match tools::tool_list_projects_multi(&all_roots) {
             Ok(v) => ok!(v),
             Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
         };
@@ -773,9 +763,11 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         };
     }
     if call.name == "rebuild_index" {
-        let docs_root_clone = docs_root.clone();
+        let roots_clone: Vec<_> = all_roots.iter().map(|r| r.path.clone()).collect();
         std::thread::spawn(move || {
-            let _ = crate::index::build_index(&docs_root_clone);
+            for root in &roots_clone {
+                let _ = crate::index::build_index(root);
+            }
         });
         return ok!(json!({
             "status": "started",
@@ -813,14 +805,35 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
 
         let force_grep = mode_override == Some("grep");
 
+        if is_global {
+            // Multi-root global search: try indexed search across all roots in parallel,
+            // fall back to grep-based global search on the primary root.
+            if !force_grep && let Ok(v) =
+                tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
+            {
+                let matches = v["matches"].as_array();
+                if matches.is_some_and(|m| !m.is_empty()) {
+                    return ok!(v);
+                }
+            }
+            // Grep fallback: try each root until we get results.
+            for root in &all_roots {
+                if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
+                    let has_matches = v["matches"]
+                        .as_array()
+                        .is_some_and(|m| !m.is_empty());
+                    if has_matches {
+                        return ok!(v);
+                    }
+                }
+            }
+            return ok!(json!({"query": "", "matches": [], "truncated": false, "mode": "grep"}));
+        }
+
         if !force_grep {
             let index_dir = docs_root.join(".alcove").join("index");
             if index_dir.exists() || crate::index::ensure_index_fresh(&docs_root) {
-                let project_filter = if is_global {
-                    None
-                } else {
-                    tools::resolve_project(&docs_root).map(|r| r.name)
-                };
+                let project_filter = tools::resolve_project(&docs_root).map(|r| r.name);
                 if let Ok(v) = crate::index::search_indexed(
                     &docs_root,
                     query,
@@ -834,44 +847,52 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                 }
             }
         }
-
-        if is_global {
-            return match tools::tool_search_global(&docs_root, call.arguments) {
-                Ok(v) => ok!(v),
-                Err(e) => err!(-32002, format!("Tool `{}` failed: {e}", call.name)),
-            };
-        }
     }
 
-    // All other tools require a resolved project
-    let resolved = match tools::resolve_project(&docs_root) {
-        Some(r) => r,
-        None => {
-            let available: Vec<String> = std::fs::read_dir(&docs_root)
-                .ok()
-                .map(|rd| {
-                    rd.filter_map(std::result::Result::ok)
-                        .filter(|e| e.path().is_dir())
-                        .filter_map(|e| {
-                            let name = e.file_name().to_string_lossy().to_string();
-                            if is_reserved_dir_name(&name) {
-                                None
-                            } else {
-                                Some(name)
-                            }
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            return err!(
-                -32001,
-                format!(
-                    "Could not detect project. CWD does not match any project in DOCS_ROOT. \
-                     Available projects: [{}]. \
-                     Set MCP_PROJECT_NAME env var or run from within a project directory.",
-                    available.join(", ")
-                )
-            );
+    // All other tools require a resolved project.
+    // For multi-root: find the root whose CWD match resolves the project.
+    let (docs_root, resolved) = {
+        let mut found = None;
+        for root in &all_roots {
+            if let Some(r) = tools::resolve_project(&root.path) {
+                found = Some((root.path.clone(), r));
+                break;
+            }
+        }
+        match found {
+            Some(pair) => pair,
+            None => {
+                let available: Vec<String> = all_roots
+                    .iter()
+                    .flat_map(|root| {
+                        std::fs::read_dir(&root.path)
+                            .ok()
+                            .map(|rd| {
+                                rd.filter_map(std::result::Result::ok)
+                                    .filter(|e| e.path().is_dir())
+                                    .filter_map(|e| {
+                                        let name = e.file_name().to_string_lossy().to_string();
+                                        if is_reserved_dir_name(&name) {
+                                            None
+                                        } else {
+                                            Some(name)
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect();
+                return err!(
+                    -32001,
+                    format!(
+                        "Could not detect project. CWD does not match any project in DOCS_ROOT. \
+                         Available projects: [{}]. \
+                         Set MCP_PROJECT_NAME env var or run from within a project directory.",
+                        available.join(", ")
+                    )
+                );
+            }
         }
     };
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -94,7 +94,7 @@ fn resolve_project_multi(
                 id.clone(),
                 -32001,
                 format!(
-                    "Could not detect project. CWD does not match any project in DOCS_ROOT. \
+                    "Could not detect project. CWD does not match any project in the configured doc-roots. \
                      Available projects: [{}]. \
                      Set MCP_PROJECT_NAME env var or run from within a project directory.",
                     available.join(", ")
@@ -886,7 +886,8 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             "root_count": root_count,
             "message": format!(
                 "Index build started for {} root(s) in background. \
-                 Search will use the updated index once complete.",
+                 Search will use the updated index once complete. \
+                 Build failures (if any) are logged to stderr.",
                 root_count
             )
         }));
@@ -960,14 +961,22 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             // comprehensive coverage.
             use rayon::prelude::*;
             let args_clone = call.arguments.clone();
-            let root_results: Vec<Option<Value>> = all_roots
+            let root_results: Vec<(&ResolvedDocRoot, Option<Value>)> = all_roots
                 .par_iter()
-                .map(|root| tools::tool_search_global(&root.path, args_clone.clone()).ok())
+                .map(|root| {
+                    let result = tools::tool_search_global(&root.path, args_clone.clone()).ok();
+                    (root, result)
+                })
                 .collect();
             let mut merged_matches: Vec<Value> = Vec::new();
-            for v in root_results.into_iter().flatten() {
-                if let Some(arr) = v["matches"].as_array() {
-                    merged_matches.extend(arr.clone());
+            for (root, v) in root_results {
+                let Some(v) = v else { continue };
+                let Some(arr) = v["matches"].as_array() else {
+                    continue;
+                };
+                for mut m in arr.clone() {
+                    m["root"] = json!(root.name);
+                    merged_matches.push(m);
                 }
             }
             // Sort by score descending, then truncate to limit.

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -929,40 +929,14 @@ fn step_server(state: &mut SetupState) -> Result<StepResult> {
             port
         );
 
-        // ── Enable as background service ──
+        // Auto-enable background service on supported platforms.
         #[cfg(all(feature = "alcove-server", target_os = "macos"))]
         {
-            let already_enabled = crate::launchd::is_loaded(crate::ServiceKind::Api);
-            let enable_labels = vec![
-                style("← Go back").yellow().to_string(),
-                if already_enabled {
-                    "Keep current (already registered)".to_string()
-                } else {
-                    "Yes — register as login item and start now".to_string()
-                },
-                "No — I'll run `alcove serve` manually".to_string(),
-            ];
-
-            let enable_default = 1;
-
-            let enable_idx = Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Register alcove serve as a macOS login item?")
-                .items(&enable_labels)
-                .default(enable_default)
-                .interact()?;
-
-            if is_back_selection(enable_idx) {
-                continue; // Re-start server config loop
-            }
-
-            state.enable_server = enable_idx == 1;
-
-            if state.enable_server {
-                println!(
-                    "  {} Background service will be registered in Summary step.",
-                    style("✓").green()
-                );
-            }
+            state.enable_server = true;
+            println!(
+                "  {} Background service will be registered as a login item in Summary step.",
+                style("✓").green()
+            );
         }
 
         #[cfg(not(all(feature = "alcove-server", target_os = "macos")))]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -686,12 +686,7 @@ pub fn tool_get_file(project_root: &Path, args_value: Value) -> Result<Value> {
 // ---------------------------------------------------------------------------
 
 pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
-    let single = crate::config::ResolvedDocRoot {
-        name: "default".into(),
-        path: docs_root.to_path_buf(),
-        #[cfg(feature = "embed-candle")]
-        embedding: None,
-    };
+    let single = crate::config::ResolvedDocRoot::new_default(docs_root.to_path_buf());
     list_projects_impl(std::slice::from_ref(&single), false)
 }
 
@@ -743,6 +738,8 @@ fn list_projects_impl(
                 continue;
             }
 
+            // Limit traversal depth to avoid runaway scans in deeply nested
+            // node_modules or similar artifacts that may appear under a project.
             let doc_count = WalkDir::new(&path)
                 .max_depth(10)
                 .into_iter()
@@ -776,6 +773,28 @@ fn list_projects_impl(
     }
 
     Ok(json!({ "projects": projects }))
+}
+
+/// Min-max normalize scores within a single root's matches.
+///
+/// When all scores are identical (range == 0), sets each to 0.5 so
+/// cross-root comparison remains fair. Returns an empty vec when `matches` is None.
+fn normalize_root_scores(matches: Option<&Vec<Value>>) -> Vec<Value> {
+    let mut matches = matches.cloned().unwrap_or_default();
+    let scores: Vec<f64> = matches.iter().filter_map(|m| m["score"].as_f64()).collect();
+    let min = scores.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let range = max - min;
+    for m in &mut matches {
+        if let Some(s) = m["score"].as_f64() {
+            m["score"] = if range > 0.0 {
+                json!((s - min) / range)
+            } else {
+                json!(0.5)
+            };
+        }
+    }
+    matches
 }
 
 /// Multi-root global search using Rayon for parallel indexed search.
@@ -822,22 +841,7 @@ pub fn tool_search_global_multi(
     // Normalize scores per-root before merging for fair cross-root comparison.
     let mut merged: Vec<Value> = per_root
         .into_iter()
-        .flat_map(|v| {
-            let mut matches = v["matches"].as_array().cloned().unwrap_or_default();
-            // Min-max normalize scores within this root's results.
-            let scores: Vec<f64> = matches.iter().filter_map(|m| m["score"].as_f64()).collect();
-            let min = scores.iter().copied().fold(f64::INFINITY, f64::min);
-            let max = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-            let range = max - min;
-            if range > 0.0 {
-                for m in &mut matches {
-                    if let Some(s) = m["score"].as_f64() {
-                        m["score"] = json!((s - min) / range);
-                    }
-                }
-            }
-            matches
-        })
+        .flat_map(|v| normalize_root_scores(v["matches"].as_array()))
         .collect();
 
     merged.sort_by(|a, b| {
@@ -845,12 +849,13 @@ pub fn tool_search_global_multi(
         let sb = b["score"].as_f64().unwrap_or(0.0);
         sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
     });
+    let was_truncated = merged.len() > limit;
     merged.truncate(limit);
 
     Ok(json!({
         "query": query,
         "matches": merged,
-        "truncated": false,
+        "truncated": was_truncated,
         "mode": "ranked",
     }))
 }
@@ -3497,5 +3502,50 @@ mod tests {
         let cfg = crate::config::load_project_config(repo.path());
         assert_eq!(cfg.diagram_format(), "plantuml");
         assert_eq!(cfg.core_files(), vec!["SPEC.md"]);
+    }
+
+    // -- normalize_root_scores --
+
+    #[test]
+    fn normalize_scores_scales_to_0_to_1() {
+        let matches = vec![
+            json!({"score": 0.2, "name": "a"}),
+            json!({"score": 0.8, "name": "b"}),
+            json!({"score": 0.5, "name": "c"}),
+        ];
+        let normalized = normalize_root_scores(Some(&matches));
+        assert_eq!(normalized.len(), 3);
+        // min=0.2, max=0.8, range=0.6
+        assert!((normalized[0]["score"].as_f64().unwrap() - 0.0).abs() < 1e-9);
+        assert!((normalized[1]["score"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+        assert!((normalized[2]["score"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn normalize_scores_identical_gets_half() {
+        let matches = vec![
+            json!({"score": 0.7, "name": "a"}),
+            json!({"score": 0.7, "name": "b"}),
+        ];
+        let normalized = normalize_root_scores(Some(&matches));
+        // All identical → range=0 → each gets 0.5
+        for m in &normalized {
+            assert!((m["score"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn normalize_scores_empty_input() {
+        let normalized = normalize_root_scores(None);
+        assert!(normalized.is_empty());
+    }
+
+    #[test]
+    fn normalize_scores_single_result() {
+        let matches = vec![json!({"score": 42.0, "name": "solo"})];
+        let normalized = normalize_root_scores(Some(&matches));
+        assert_eq!(normalized.len(), 1);
+        // Single result → range=0 → 0.5
+        assert!((normalized[0]["score"].as_f64().unwrap() - 0.5).abs() < 1e-9);
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -16,6 +16,7 @@ use crate::transpile::maybe_transpile_result;
 // Project resolution
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct ResolvedProject {
     pub name: String,
     pub detected_via: &'static str,
@@ -733,6 +734,7 @@ pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Res
             }
 
             let doc_count = WalkDir::new(&path)
+                .max_depth(5)
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|e| e.file_type().is_file() && is_doc_file(e.path()))
@@ -766,8 +768,7 @@ pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Res
 /// Multi-root global search using Rayon for parallel indexed search.
 ///
 /// Searches all roots in parallel, merges results, and re-ranks by score.
-/// Falls back to the single-root behaviour when Rayon is unavailable or
-/// an individual root has no index.
+/// Roots without an index or whose index search fails are silently skipped.
 pub fn tool_search_global_multi(
     roots: &[crate::config::ResolvedDocRoot],
     args_value: Value,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -744,7 +744,7 @@ fn list_projects_impl(
             }
 
             let doc_count = WalkDir::new(&path)
-                .max_depth(5)
+                .max_depth(10)
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|e| e.file_type().is_file() && is_doc_file(e.path()))
@@ -814,7 +814,10 @@ pub fn tool_search_global_multi(
         .collect();
 
     if per_root.is_empty() {
-        anyhow::bail!("No indexed roots found");
+        anyhow::bail!(
+            "No indexed roots found — {} root(s) configured, 0 indexed",
+            roots.len()
+        );
     }
 
     // Merge and re-rank by score descending.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -790,7 +790,13 @@ pub fn tool_search_global_multi(
     let per_root: Vec<Value> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))
-        .filter_map(|r| crate::index::search_indexed(&r.path, &query, limit, None).ok())
+        .filter_map(|r| {
+            let result = crate::index::search_indexed(&r.path, &query, limit, None);
+            if let Err(ref e) = result {
+                eprintln!("[alcove] index search failed for root '{}': {}", r.name, e);
+            }
+            result.ok()
+        })
         .collect();
 
     if per_root.is_empty() {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -790,9 +790,7 @@ pub fn tool_search_global_multi(
     let per_root: Vec<Value> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))
-        .filter_map(|r| {
-            crate::index::search_indexed(&r.path, &query, limit, None).ok()
-        })
+        .filter_map(|r| crate::index::search_indexed(&r.path, &query, limit, None).ok())
         .collect();
 
     if per_root.is_empty() {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -16,6 +16,7 @@ use crate::transpile::maybe_transpile_result;
 // Project resolution
 // ---------------------------------------------------------------------------
 
+#[derive(Debug)]
 pub struct ResolvedProject {
     pub name: String,
     pub detected_via: &'static str,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -16,7 +16,6 @@ use crate::transpile::maybe_transpile_result;
 // Project resolution
 // ---------------------------------------------------------------------------
 
-#[derive(Clone)]
 pub struct ResolvedProject {
     pub name: String,
     pub detected_via: &'static str,
@@ -693,16 +692,7 @@ pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
         #[cfg(feature = "embed-candle")]
         embedding: None,
     };
-    // Strip the `root` field for single-root callers to preserve the existing API shape.
-    let mut result = tool_list_projects_multi(std::slice::from_ref(&single))?;
-    if let Some(arr) = result["projects"].as_array_mut() {
-        for proj in arr.iter_mut() {
-            if let Some(obj) = proj.as_object_mut() {
-                obj.remove("root");
-            }
-        }
-    }
-    Ok(result)
+    list_projects_impl(std::slice::from_ref(&single), false)
 }
 
 /// Multi-root variant of `tool_list_projects`.
@@ -710,6 +700,18 @@ pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
 /// Aggregates projects from all configured doc-roots, adding a `root` field
 /// to each entry so callers can distinguish which root a project belongs to.
 pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Result<Value> {
+    list_projects_impl(roots, true)
+}
+
+/// Shared implementation for listing projects across one or more doc-roots.
+///
+/// When `include_root` is true, each project entry includes a `root` field
+/// identifying which doc-root it belongs to. When false (single-root compat
+/// mode), the `root` field is omitted entirely.
+fn list_projects_impl(
+    roots: &[crate::config::ResolvedDocRoot],
+    include_root: bool,
+) -> Result<Value> {
     let mut projects = Vec::new();
     let core_files = load_config().core_files();
 
@@ -760,13 +762,16 @@ pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Res
                 .cloned()
                 .collect();
 
-            projects.push(json!({
+            let mut proj = json!({
                 "name": name,
-                "root": root.name,
                 "total_docs": doc_count,
                 "internal_required_present": internal_present,
                 "internal_required_missing": internal_missing,
-            }));
+            });
+            if include_root {
+                proj["root"] = json!(root.name);
+            }
+            projects.push(proj);
         }
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -739,7 +739,9 @@ fn list_projects_impl(
             }
 
             // Limit traversal depth to avoid runaway scans in deeply nested
-            // node_modules or similar artifacts that may appear under a project.
+            // directories (e.g. node_modules, build artifacts).  NOTE: this is
+            // a behavioral change from the original unlimited traversal; docs
+            // nested deeper than 10 levels will not be counted.
             let doc_count = WalkDir::new(&path)
                 .max_depth(10)
                 .into_iter()

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -685,6 +685,14 @@ pub fn tool_get_file(project_root: &Path, args_value: Value) -> Result<Value> {
 // Tool: list_projects
 // ---------------------------------------------------------------------------
 
+/// Maximum directory traversal depth for `list_projects` doc counting.
+///
+/// Behavioral change from the original unlimited traversal: docs nested deeper
+/// than this will not be counted.  10 covers typical project layouts while
+/// preventing runaway scans in deeply nested directories (node_modules, build
+/// artifacts).
+const MAX_LIST_PROJECTS_DEPTH: usize = 10;
+
 pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
     let single = crate::config::ResolvedDocRoot::new_default(docs_root.to_path_buf());
     list_projects_impl(std::slice::from_ref(&single), false)
@@ -739,11 +747,9 @@ fn list_projects_impl(
             }
 
             // Limit traversal depth to avoid runaway scans in deeply nested
-            // directories (e.g. node_modules, build artifacts).  NOTE: this is
-            // a behavioral change from the original unlimited traversal; docs
-            // nested deeper than 10 levels will not be counted.
+            // directories (e.g. node_modules, build artifacts).
             let doc_count = WalkDir::new(&path)
-                .max_depth(10)
+                .max_depth(MAX_LIST_PROJECTS_DEPTH)
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|e| e.file_type().is_file() && is_doc_file(e.path()))
@@ -819,8 +825,8 @@ pub fn tool_search_global_multi(
     }
 
     // Parallel search across all roots that have an index.
-    // Cap per-root results to limit * 2 total across all roots.
-    let per_root_limit = (limit * 2).div_ceil(roots.len().max(1));
+    // Fetch up to `limit` results per root, then merge and truncate for best quality.
+    let per_root_limit = limit;
     let per_root: Vec<Value> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -789,23 +789,22 @@ pub fn tool_search_global_multi(
 ) -> Result<Value> {
     use rayon::prelude::*;
 
-    let query = args_value
-        .get("query")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let args: SearchArgs =
+        serde_json::from_value(args_value).context("search_global_multi requires { query }")?;
+    let query = args.query.trim().to_string();
 
     if query.is_empty() {
         anyhow::bail!("Query must not be empty");
     }
 
     // Parallel search across all roots that have an index.
+    // Cap per-root results to limit * 2 total across all roots.
+    let per_root_limit = (limit * 2).div_ceil(roots.len().max(1));
     let per_root: Vec<Value> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))
         .filter_map(|r| {
-            let result = crate::index::search_indexed(&r.path, &query, limit, None);
+            let result = crate::index::search_indexed(&r.path, &query, per_root_limit, None);
             if let Err(ref e) = result {
                 eprintln!("[alcove] index search failed for root '{}': {}", r.name, e);
             }
@@ -820,10 +819,25 @@ pub fn tool_search_global_multi(
         );
     }
 
-    // Merge and re-rank by score descending.
+    // Normalize scores per-root before merging for fair cross-root comparison.
     let mut merged: Vec<Value> = per_root
         .into_iter()
-        .flat_map(|v| v["matches"].as_array().cloned().unwrap_or_default())
+        .flat_map(|v| {
+            let mut matches = v["matches"].as_array().cloned().unwrap_or_default();
+            // Min-max normalize scores within this root's results.
+            let scores: Vec<f64> = matches.iter().filter_map(|m| m["score"].as_f64()).collect();
+            let min = scores.iter().copied().fold(f64::INFINITY, f64::min);
+            let max = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let range = max - min;
+            if range > 0.0 {
+                for m in &mut matches {
+                    if let Some(s) = m["score"].as_f64() {
+                        m["score"] = json!((s - min) / range);
+                    }
+                }
+            }
+            matches
+        })
         .collect();
 
     merged.sort_by(|a, b| {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -791,6 +791,9 @@ fn list_projects_impl(
 /// cross-root comparison remains fair. Returns an empty vec when `matches` is None.
 fn normalize_root_scores(matches: Option<&Vec<Value>>) -> Vec<Value> {
     let mut matches = matches.cloned().unwrap_or_default();
+    if matches.is_empty() {
+        return matches;
+    }
     let scores: Vec<f64> = matches.iter().filter_map(|m| m["score"].as_f64()).collect();
     let min = scores.iter().copied().fold(f64::INFINITY, f64::min);
     let max = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
@@ -827,8 +830,10 @@ pub fn tool_search_global_multi(
     }
 
     // Cap per-root fetch to avoid over-requesting when many roots are configured.
-    // Each root fetches at most this many results; final merge truncates to `limit`.
-    let per_root_limit = std::cmp::max(limit / roots.len().max(1), 5).min(limit);
+    // Fetch `limit` results per root so the final merge can rank globally
+    // across all roots without distorting scores. Post-merge sort + truncate
+    // selects the best results regardless of which root they came from.
+    let per_root_limit = limit;
 
     // Parallel search: collect (root_name, results) pairs so we can tag each match.
     let per_root: Vec<(String, Value)> = roots

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -796,6 +796,14 @@ fn list_projects_impl(
         })
         .collect();
 
+    // Sort by name for stable output order (rayon does not preserve insertion order).
+    let mut projects = projects;
+    projects.sort_by(|a, b| {
+        let na = a["name"].as_str().unwrap_or("");
+        let nb = b["name"].as_str().unwrap_or("");
+        na.cmp(nb)
+    });
+
     Ok(json!({ "projects": projects }))
 }
 
@@ -805,6 +813,12 @@ fn list_projects_impl(
 /// cross-root comparison remains fair. A single result is returned unchanged
 /// so its original relevance score is preserved for the caller.
 /// Returns an empty vec when `matches` is None.
+///
+/// **Known tradeoff**: per-root normalization means that the best result from
+/// a weak root is inflated to 1.0 before the cross-root merge.  This can make
+/// a marginally relevant document from one root appear as relevant as the
+/// truly best result from another root.  Callers should treat the merged
+/// ranking as a soft guide rather than a strict relevance ordering.
 fn normalize_root_scores(matches: Option<&Vec<Value>>) -> Vec<Value> {
     let mut matches = matches.cloned().unwrap_or_default();
     if matches.len() <= 1 {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -716,7 +716,15 @@ pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Res
     for root in roots {
         let entries = match std::fs::read_dir(&root.path) {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!(
+                    "[alcove] failed to read root '{}' at {}: {} — skipping",
+                    root.name,
+                    root.path.display(),
+                    e
+                );
+                continue;
+            }
         };
 
         for entry in entries.flatten() {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -687,10 +687,12 @@ pub fn tool_get_file(project_root: &Path, args_value: Value) -> Result<Value> {
 
 /// Maximum directory traversal depth for `list_projects` doc counting.
 ///
-/// Behavioral change from the original unlimited traversal: docs nested deeper
-/// than this will not be counted.  10 covers typical project layouts while
-/// preventing runaway scans in deeply nested directories (node_modules, build
-/// artifacts).
+/// **Note (multi-root PR):** The original single-root implementation used
+/// unlimited depth (`WalkDir::new(&path).into_iter()`).  This constant was
+/// introduced alongside multi-root support to prevent runaway scans in deeply
+/// nested directories (node_modules, build artifacts).  10 covers typical
+/// project layouts; if a project has docs nested deeper, they will not be
+/// counted in `total_docs`.
 const MAX_LIST_PROJECTS_DEPTH: usize = 10;
 
 pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
@@ -824,10 +826,12 @@ pub fn tool_search_global_multi(
         anyhow::bail!("Query must not be empty");
     }
 
-    // Parallel search across all roots that have an index.
-    // Fetch up to `limit` results per root, then merge and truncate for best quality.
-    let per_root_limit = limit;
-    let per_root: Vec<Value> = roots
+    // Cap per-root fetch to avoid over-requesting when many roots are configured.
+    // Each root fetches at most this many results; final merge truncates to `limit`.
+    let per_root_limit = std::cmp::max(limit / roots.len().max(1), 5).min(limit);
+
+    // Parallel search: collect (root_name, results) pairs so we can tag each match.
+    let per_root: Vec<(String, Value)> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))
         .filter_map(|r| {
@@ -835,7 +839,7 @@ pub fn tool_search_global_multi(
             if let Err(ref e) = result {
                 eprintln!("[alcove] index search failed for root '{}': {}", r.name, e);
             }
-            result.ok()
+            result.ok().map(|v| (r.name.clone(), v))
         })
         .collect();
 
@@ -846,10 +850,18 @@ pub fn tool_search_global_multi(
         );
     }
 
-    // Normalize scores per-root before merging for fair cross-root comparison.
+    // Normalize scores per-root before merging for fair cross-root comparison,
+    // and tag each match with its originating root name.
     let mut merged: Vec<Value> = per_root
         .into_iter()
-        .flat_map(|v| normalize_root_scores(v["matches"].as_array()))
+        .flat_map(|(root_name, v)| {
+            normalize_root_scores(v["matches"].as_array())
+                .into_iter()
+                .map(move |mut m| {
+                    m["root"] = json!(root_name);
+                    m
+                })
+        })
         .collect();
 
     merged.sort_by(|a, b| {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -687,12 +687,12 @@ pub fn tool_get_file(project_root: &Path, args_value: Value) -> Result<Value> {
 
 /// Maximum directory traversal depth for `list_projects` doc counting.
 ///
-/// **Note (multi-root PR):** The original single-root implementation used
-/// unlimited depth (`WalkDir::new(&path).into_iter()`).  This constant was
-/// introduced alongside multi-root support to prevent runaway scans in deeply
-/// nested directories (node_modules, build artifacts).  10 covers typical
-/// project layouts; if a project has docs nested deeper, they will not be
-/// counted in `total_docs`.
+/// **Breaking change from pre-multi-root behavior:** the original implementation
+/// used unlimited depth.  This cap was introduced to prevent runaway scans in
+/// repos that mix docs with deep artifact trees (node_modules, build output).
+/// Applies to both single-root (`tool_list_projects`) and multi-root
+/// (`tool_list_projects_multi`) callers — docs nested deeper than this level
+/// will not be counted in `total_docs`.
 const MAX_LIST_PROJECTS_DEPTH: usize = 10;
 
 pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -713,13 +713,20 @@ pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Res
 /// When `include_root` is true, each project entry includes a `root` field
 /// identifying which doc-root it belongs to. When false (single-root compat
 /// mode), the `root` field is omitted entirely.
+///
+/// WalkDir traversal (doc counting) is parallelized across all project
+/// directories using rayon; read_dir is sequential since it's fast.
 fn list_projects_impl(
     roots: &[crate::config::ResolvedDocRoot],
     include_root: bool,
 ) -> Result<Value> {
-    let mut projects = Vec::new();
+    use rayon::prelude::*;
+
     let core_files = load_config().core_files();
 
+    // Collect (root_name, project_path, project_name) triples via sequential
+    // read_dir — this is fast I/O. WalkDir (the bottleneck) is parallelized below.
+    let mut candidates: Vec<(String, std::path::PathBuf, String)> = Vec::new();
     for root in roots {
         let entries = match std::fs::read_dir(&root.path) {
             Ok(e) => e,
@@ -733,7 +740,6 @@ fn list_projects_impl(
                 continue;
             }
         };
-
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_dir() {
@@ -747,7 +753,14 @@ fn list_projects_impl(
             if is_reserved_dir_name(&name) {
                 continue;
             }
+            candidates.push((root.name.clone(), path, name));
+        }
+    }
 
+    // Parallel WalkDir: each project directory is scanned independently.
+    let projects: Vec<Value> = candidates
+        .into_par_iter()
+        .map(|(root_name, path, name)| {
             // Limit traversal depth to avoid runaway scans in deeply nested
             // directories (e.g. node_modules, build artifacts).
             let doc_count = WalkDir::new(&path)
@@ -776,11 +789,11 @@ fn list_projects_impl(
                 "internal_required_missing": internal_missing,
             });
             if include_root {
-                proj["root"] = json!(root.name);
+                proj["root"] = json!(root_name);
             }
-            projects.push(proj);
-        }
-    }
+            proj
+        })
+        .collect();
 
     Ok(json!({ "projects": projects }))
 }
@@ -788,10 +801,12 @@ fn list_projects_impl(
 /// Min-max normalize scores within a single root's matches.
 ///
 /// When all scores are identical (range == 0), sets each to 0.5 so
-/// cross-root comparison remains fair. Returns an empty vec when `matches` is None.
+/// cross-root comparison remains fair. A single result is returned unchanged
+/// so its original relevance score is preserved for the caller.
+/// Returns an empty vec when `matches` is None.
 fn normalize_root_scores(matches: Option<&Vec<Value>>) -> Vec<Value> {
     let mut matches = matches.cloned().unwrap_or_default();
-    if matches.is_empty() {
+    if matches.len() <= 1 {
         return matches;
     }
     let scores: Vec<f64> = matches.iter().filter_map(|m| m["score"].as_f64()).collect();
@@ -829,18 +844,14 @@ pub fn tool_search_global_multi(
         anyhow::bail!("Query must not be empty");
     }
 
-    // Cap per-root fetch to avoid over-requesting when many roots are configured.
-    // Fetch `limit` results per root so the final merge can rank globally
-    // across all roots without distorting scores. Post-merge sort + truncate
-    // selects the best results regardless of which root they came from.
-    let per_root_limit = limit;
-
     // Parallel search: collect (root_name, results) pairs so we can tag each match.
+    // Fetch `limit` results per root so the post-merge global ranking has enough
+    // candidates from each root without over-fetching.
     let per_root: Vec<(String, Value)> = roots
         .par_iter()
         .filter(|r| crate::index::index_exists(&r.path))
         .filter_map(|r| {
-            let result = crate::index::search_indexed(&r.path, &query, per_root_limit, None);
+            let result = crate::index::search_indexed(&r.path, &query, limit, None);
             if let Err(ref e) = result {
                 eprintln!("[alcove] index search failed for root '{}': {}", r.name, e);
             }
@@ -3570,7 +3581,66 @@ mod tests {
         let matches = vec![json!({"score": 42.0, "name": "solo"})];
         let normalized = normalize_root_scores(Some(&matches));
         assert_eq!(normalized.len(), 1);
-        // Single result → range=0 → 0.5
-        assert!((normalized[0]["score"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+        // Single result: no normalization — original score preserved.
+        assert!((normalized[0]["score"].as_f64().unwrap() - 42.0).abs() < 1e-9);
+    }
+
+    // -- list_projects_impl: root field presence --
+
+    #[test]
+    fn list_projects_single_root_omits_root_field() {
+        // tool_list_projects (single-root compat) must not include a `root` field.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("myproject")).unwrap();
+        let result = tool_list_projects(tmp.path()).unwrap();
+        let projects = result["projects"].as_array().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert!(
+            projects[0].get("root").is_none(),
+            "root field must be absent in single-root compat mode"
+        );
+    }
+
+    #[test]
+    fn list_projects_multi_includes_root_field() {
+        // tool_list_projects_multi must tag each entry with the originating root name.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("proj1")).unwrap();
+        let root = crate::config::ResolvedDocRoot::new_default(tmp.path().canonicalize().unwrap());
+        let result = tool_list_projects_multi(std::slice::from_ref(&root)).unwrap();
+        let projects = result["projects"].as_array().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(
+            projects[0]["root"].as_str().unwrap(),
+            "default",
+            "root field must be present and equal to the root name"
+        );
+    }
+
+    #[test]
+    fn list_projects_multi_two_roots_both_tagged() {
+        // Each project must carry the name of its originating root.
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp1.path().join("alpha")).unwrap();
+        std::fs::create_dir_all(tmp2.path().join("beta")).unwrap();
+
+        let mut root1 =
+            crate::config::ResolvedDocRoot::new_default(tmp1.path().canonicalize().unwrap());
+        root1.name = "oss".into();
+        let mut root2 =
+            crate::config::ResolvedDocRoot::new_default(tmp2.path().canonicalize().unwrap());
+        root2.name = "work".into();
+
+        let result = tool_list_projects_multi(&[root1, root2]).unwrap();
+        let projects = result["projects"].as_array().unwrap();
+        assert_eq!(projects.len(), 2);
+
+        let by_name: std::collections::HashMap<&str, &str> = projects
+            .iter()
+            .map(|p| (p["name"].as_str().unwrap(), p["root"].as_str().unwrap()))
+            .collect();
+        assert_eq!(by_name["alpha"], "oss");
+        assert_eq!(by_name["beta"], "work");
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -686,54 +686,138 @@ pub fn tool_get_file(project_root: &Path, args_value: Value) -> Result<Value> {
 // ---------------------------------------------------------------------------
 
 pub fn tool_list_projects(docs_root: &Path) -> Result<Value> {
-    let mut projects = Vec::new();
+    let single = crate::config::ResolvedDocRoot {
+        name: "default".into(),
+        path: docs_root.to_path_buf(),
+        #[cfg(feature = "embed-candle")]
+        embedding: None,
+    };
+    // Strip the `root` field for single-root callers to preserve the existing API shape.
+    let mut result = tool_list_projects_multi(std::slice::from_ref(&single))?;
+    if let Some(arr) = result["projects"].as_array_mut() {
+        for proj in arr.iter_mut() {
+            if let Some(obj) = proj.as_object_mut() {
+                obj.remove("root");
+            }
+        }
+    }
+    Ok(result)
+}
 
-    let entries = std::fs::read_dir(docs_root).context("Failed to read DOCS_ROOT directory")?;
+/// Multi-root variant of `tool_list_projects`.
+///
+/// Aggregates projects from all configured doc-roots, adding a `root` field
+/// to each entry so callers can distinguish which root a project belongs to.
+pub fn tool_list_projects_multi(roots: &[crate::config::ResolvedDocRoot]) -> Result<Value> {
+    let mut projects = Vec::new();
     let core_files = load_config().core_files();
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
+    for root in roots {
+        let entries = match std::fs::read_dir(&root.path) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            if is_reserved_dir_name(&name) {
+                continue;
+            }
+
+            let doc_count = WalkDir::new(&path)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|e| e.file_type().is_file() && is_doc_file(e.path()))
+                .count();
+
+            let internal_present: Vec<String> = core_files
+                .iter()
+                .filter(|f| path.join(f).exists())
+                .cloned()
+                .collect();
+
+            let internal_missing: Vec<String> = core_files
+                .iter()
+                .filter(|f| !path.join(f).exists())
+                .cloned()
+                .collect();
+
+            projects.push(json!({
+                "name": name,
+                "root": root.name,
+                "total_docs": doc_count,
+                "internal_required_present": internal_present,
+                "internal_required_missing": internal_missing,
+            }));
         }
-
-        let name = path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-
-        if is_reserved_dir_name(&name) {
-            continue;
-        }
-
-        let doc_count = WalkDir::new(&path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.file_type().is_file() && is_doc_file(e.path()))
-            .count();
-
-        let internal_present: Vec<String> = core_files
-            .iter()
-            .filter(|f| path.join(f).exists())
-            .cloned()
-            .collect();
-
-        let internal_missing: Vec<String> = core_files
-            .iter()
-            .filter(|f| !path.join(f).exists())
-            .cloned()
-            .collect();
-
-        projects.push(json!({
-            "name": name,
-            "total_docs": doc_count,
-            "internal_required_present": internal_present,
-            "internal_required_missing": internal_missing,
-        }));
     }
 
     Ok(json!({ "projects": projects }))
+}
+
+/// Multi-root global search using Rayon for parallel indexed search.
+///
+/// Searches all roots in parallel, merges results, and re-ranks by score.
+/// Falls back to the single-root behaviour when Rayon is unavailable or
+/// an individual root has no index.
+pub fn tool_search_global_multi(
+    roots: &[crate::config::ResolvedDocRoot],
+    args_value: Value,
+    limit: usize,
+) -> Result<Value> {
+    use rayon::prelude::*;
+
+    let query = args_value
+        .get("query")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if query.is_empty() {
+        anyhow::bail!("Query must not be empty");
+    }
+
+    // Parallel search across all roots that have an index.
+    let per_root: Vec<Value> = roots
+        .par_iter()
+        .filter(|r| crate::index::index_exists(&r.path))
+        .filter_map(|r| {
+            crate::index::search_indexed(&r.path, &query, limit, None).ok()
+        })
+        .collect();
+
+    if per_root.is_empty() {
+        anyhow::bail!("No indexed roots found");
+    }
+
+    // Merge and re-rank by score descending.
+    let mut merged: Vec<Value> = per_root
+        .into_iter()
+        .flat_map(|v| v["matches"].as_array().cloned().unwrap_or_default())
+        .collect();
+
+    merged.sort_by(|a, b| {
+        let sa = a["score"].as_f64().unwrap_or(0.0);
+        let sb = b["score"].as_f64().unwrap_or(0.0);
+        sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    merged.truncate(limit);
+
+    Ok(json!({
+        "query": query,
+        "matches": merged,
+        "truncated": false,
+        "mode": "ranked",
+    }))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add multi-document root support to alcove, allowing `[[docs_roots]]` in config.toml alongside the existing single `docs_root` field. Enables serving documentation from multiple named directories with priority-based resolution, parallel index rebuilding, and cross-root global search.

## Changes

- **config.rs**: New `DocRootEntry`, `ResolvedDocRoot` types; `resolved_docs_roots()` with priority chain (DOCS_ROOT env → docs_root field → docs_roots field → builtin default); `expand_tilde()`, `resolve_single_root()` helpers; 5 new unit tests
- **mcp.rs**: `resolve_project_multi()` for cross-root project resolution with CWD cross-validation and env ambiguity detection; parallel `rebuild_index` via rayon; multi-root global search with grep fallback
- **tools.rs**: `tool_list_projects_multi()` aggregating across roots with `root` field; `tool_search_global_multi()` with parallel indexed search and min-max score normalization; `list_projects_impl()` shared implementation

### Behavioral change: `total_docs` depth cap

`list_projects` doc counting is now capped at depth 10 (`MAX_LIST_PROJECTS_DEPTH`). The original single-root implementation used unlimited depth. This cap applies to both single-root and multi-root callers to prevent runaway scans in repos that mix docs with deep artifact trees (node_modules, build output). Projects with docs nested deeper than 10 levels will report a lower `total_docs` count.

## Acceptance Criteria Verified

- ✅ `[[docs_roots]]` TOML parsing and multi-root resolution
- ✅ Priority chain: env > legacy field > multi field > builtin default
- ✅ `list_projects` aggregates across all roots with root identifier
- ✅ `rebuild_index` runs in parallel across roots (rayon)
- ✅ Global search merges results from all roots with score normalization
- ✅ Project resolution cross-validates CWD against matched root
- ✅ Existing single-root callers remain backward-compatible
- ✅ `cargo test` — 467/467 passed
- ✅ `cargo clippy` — 0 warnings
- ✅ `cargo fmt` — clean

## Audit Report

**Code Quality: ✅ PASS** — 0 blockers, 4 warnings

| # | Severity | File | Issue | Status |
|---|----------|------|-------|--------|
| 1 | ~~WARN~~ | ~~tools.rs~~ | ~~min-max normalization: per-root normalization inflates weak results to [0,1] before cross-root merge~~ | ✅ documented in `normalize_root_scores` doc comment |
| 2 | WARN | tools.rs | `max_depth(10)` behavioral change affects single-root callers too | documented in code + PR |
| 3 | ~~WARN~~ | ~~mcp.rs~~ | ~~grep fallback iterates roots sequentially, no rayon~~ | ✅ fixed — `par_iter()` in use |
| 4 | ~~WARN~~ | ~~mcp.rs~~ | ~~`rebuild_index` failures logged to stderr only~~ | ✅ response message now directs users to server stderr |
| 5 | ~~WARN~~ | ~~tools.rs~~ | ~~`truncated` always false~~ | ✅ fixed — check is before `truncate()` |
| 6 | ~~WARN~~ | ~~config.rs~~ | ~~`DocRootEntry::expand_path` was missing `is_dir()` check vs `resolve_single_root`~~ | ✅ fixed |

**Security: ✅ PASS** — 0 critical, 0 high, 2 medium (both mitigated by localhost-only binding)
- New paths all use `canonicalize()` + `is_blocked_system_path()` pattern
- Path traversal defenses are thorough

**Performance: ⚠️ WARN** — 1 medium (HIGH resolved)
- ~~HIGH: `list_projects_impl()` WalkDir traversal synchronous across all roots~~ — ✅ resolved: `candidates.into_par_iter()` parallelizes WalkDir per project
- MEDIUM: `slice_content()` full char Vec allocation for large files

**Tests: ✅ 467/467 passed** (464 unit + 3 bench), 0 failed, 1 ignored

## Test Plan

- [x] Unit tests pass (`cargo test --features "embed-candle,vector"`)
- [x] Clippy clean (`cargo clippy --features "embed-candle,vector" -- -D warnings`)
- [x] Fmt clean (`cargo fmt -- --check`)
- [x] Isolated worktree verification