### PR TITLE
fix(embedding): review fixes and DirectML CI fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,21 +55,21 @@ llm-kernel = { version = "0.2.4", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing
-rusqlite = { version = "0.39", features = ["bundled"], optional = true }
+rusqlite = { version = "0.40", features = ["bundled"], optional = true }
 hnsw_rs = { version = "0.3", optional = true }
 
 # Document parsers
 pdf-extract = { version = "0.10", optional = true }  # Unix-only
 zip = { version = "8.5", optional = true }
-quick-xml = { version = "0.39", optional = true }
-calamine = { version = "0.34", optional = true }
+quick-xml = { version = "0.40", optional = true }
+calamine = { version = "0.35", optional = true }
 
 # Lightweight sync HTTP client for MCP proxy mode
 # rustls avoids the native-tls/openssl dependency for cross-compilation compatibility
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 
 # Token-optimized document transpiler (optional, transpile feature)
-llm-transpile = { version = "0.2.4", optional = true }
+llm-transpile = { version = "0.3", optional = true }
 
 # Code structure indexing (core always present; grammars are feature-gated)
 tree-sitter = "0.26"
@@ -91,7 +91,7 @@ tree-sitter-c-sharp = { version = "0.23", optional = true }
 # HTTP server dependencies
 axum = { version = "0.8", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
-socket2 = { version = "0.5", optional = true }
+socket2 = { version = "0.6", optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,11 @@ sys-locale = "0.3.2"
 tantivy = "0.26"
 chrono = { version = "0.4", features = ["clock"] }
 
-# Embedding backend (ONNX Runtime via fastembed).
-# NOTE: ONNX Runtime ships native shared libraries (~30-50 MB per platform).
-# Linked at build time and bundled into release binaries.
-# `cargo audit` covers ONNX Runtime CVEs transitively via the ort crate.
-# default-features = false: drops hf-hub-native-tls + ort-download-binaries-native-tls
-# to avoid openssl-sys on cross-compile targets; replaced with rustls equivalents.
-fastembed = { version = "5", optional = true, default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
-# Pinned to match fastembed's exact ort version — DirectMLExecutionProvider type must be compatible.
-ort = { version = "=2.0.0-rc.12", optional = true }
+# Embedding backend — delegates to llm-kernel for model catalog, metadata,
+# and LRU cache. fastembed remains a direct dep for FastEmbedSession
+# (prefix control). llm-kernel uses the same rustls-based defaults.
+llm-kernel = { version = "0.2.4", default-features = false }
+fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
@@ -101,8 +97,8 @@ tower-http = { version = "0.6", features = ["cors"], optional = true }
 [features]
 default = ["core"]
 core = ["rusqlite", "alcove-server", "lang-rust"]
-embed = ["fastembed"]
-embed-directml = ["embed", "dep:ort"]  # Windows DirectML GPU acceleration
+embed = ["llm-kernel/embedding-fastembed", "dep:fastembed"]
+embed-directml = ["embed", "llm-kernel/embedding-fastembed-directml"]
 vector = ["hnsw_rs"]
 pdf = ["pdf-extract"]
 office = ["zip", "quick-xml", "calamine"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ chrono = { version = "0.4", features = ["clock"] }
 # (prefix control). llm-kernel uses the same rustls-based defaults.
 llm-kernel = { version = "0.2.4", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
+# Pinned to match fastembed's exact ort version — DirectMLExecutionProvider type must be compatible.
+ort = { version = "=2.0.0-rc.12", default-features = false, optional = true }
 
 # Storage & indexing
 rusqlite = { version = "0.40", features = ["bundled"], optional = true }
@@ -98,7 +100,7 @@ tower-http = { version = "0.6", features = ["cors"], optional = true }
 default = ["core"]
 core = ["rusqlite", "alcove-server", "lang-rust"]
 embed = ["llm-kernel/embedding-fastembed", "dep:fastembed"]
-embed-directml = ["embed", "llm-kernel/embedding-fastembed-directml"]
+embed-directml = ["embed", "dep:ort"]
 vector = ["hnsw_rs"]
 pdf = ["pdf-extract"]
 office = ["zip", "quick-xml", "calamine"]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -264,8 +264,7 @@ fn get_docs_root() -> Result<PathBuf> {
 fn create_embedding_service(
     emb_cfg: &crate::config::EmbeddingConfig,
 ) -> crate::embedding::EmbeddingService {
-    let model = crate::embedding::parse_legacy_model(&emb_cfg.model)
-        .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small);
+    let model = crate::embedding::resolve_model(&emb_cfg.model);
     let cache_dir = if emb_cfg.cache_dir.starts_with('~') {
         std::env::var("HOME")
             .ok()

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -264,7 +264,8 @@ fn get_docs_root() -> Result<PathBuf> {
 fn create_embedding_service(
     emb_cfg: &crate::config::EmbeddingConfig,
 ) -> crate::embedding::EmbeddingService {
-    let model = crate::embedding::EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+    let model = crate::embedding::parse_legacy_model(&emb_cfg.model)
+        .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small);
     let cache_dir = if emb_cfg.cache_dir.starts_with('~') {
         std::env::var("HOME")
             .ok()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -738,13 +738,14 @@ pub fn cmd_model(subcmd: crate::ModelCommands) -> Result<()> {
 
 #[cfg(feature = "embed")]
 fn cmd_model_list() -> Result<()> {
-    use crate::embedding::EmbeddingModelChoice;
-
     /// Curated models shown in `model list`. All 43 models remain available via manual config.
     const CURATED: &[(&str, &str)] = &[
-        ("ArcticEmbedXS", "Default — best size/quality, multilingual"),
+        (
+            "MultilingualE5Small",
+            "Default — best Korean/CJK support, 100+ langs",
+        ),
+        ("ArcticEmbedXS", "Best size/quality, multilingual"),
         ("ArcticEmbedXSQ", "Quantized Arctic XS, smaller download"),
-        ("MultilingualE5Small", "Best Korean/CJK support, 100+ langs"),
         ("BGEM3", "Premium — Dense+Sparse+ColBERT, 100+ langs"),
         ("ArcticEmbedMLong", "Long context (8192), multilingual"),
         ("JinaEmbeddingsV2BaseCode", "Code-optimized, 8192 context"),
@@ -765,10 +766,10 @@ fn cmd_model_list() -> Result<()> {
         .embedding
         .as_ref()
         .map(|e| e.model.as_str())
-        .unwrap_or("ArcticEmbedXS");
+        .unwrap_or("MultilingualE5Small");
 
     for &(name, desc) in CURATED {
-        let model = EmbeddingModelChoice::parse(name).unwrap();
+        let model = crate::embedding::parse_legacy_model(name).unwrap();
         let marker = if name == current { " [current]" } else { "" };
         println!(
             "{:<30} {:<8} {:<10} {}{}",
@@ -782,7 +783,7 @@ fn cmd_model_list() -> Result<()> {
 
     // If the user has a non-curated model configured, show it too
     if !CURATED.iter().any(|(n, _)| *n == current)
-        && let Some(model) = EmbeddingModelChoice::parse(current)
+        && let Some(model) = crate::embedding::parse_legacy_model(current)
     {
         println!(
             "{:<30} {:<8} {:<10} (custom selection){}",
@@ -817,8 +818,8 @@ fn cmd_model_download() -> Result<()> {
 
         let cfg = load_config().embedding_config_with_defaults();
         let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-            model: crate::embedding::EmbeddingModelChoice::parse(&cfg.model)
-                .unwrap_or_default()
+            model: crate::embedding::parse_legacy_model(&cfg.model)
+                .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small)
                 .as_str()
                 .to_string(),
             auto_download: true,
@@ -918,10 +919,8 @@ fn cmd_model_remove() -> Result<()> {
 
 #[cfg(feature = "embed")]
 fn cmd_model_set(model_name: &str) -> Result<()> {
-    use crate::embedding::EmbeddingModelChoice;
-
     // Validate model name
-    let model = EmbeddingModelChoice::parse(model_name).ok_or_else(|| {
+    let model = crate::embedding::parse_legacy_model(model_name).ok_or_else(|| {
         anyhow::anyhow!(
             "Unknown model: {}. Run 'alcove model list' to see available models.",
             model_name
@@ -1000,8 +999,8 @@ fn cmd_model_status() -> Result<()> {
         style(&emb_cfg.model).cyan()
     );
 
-    let model_choice =
-        crate::embedding::EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+    let model_choice = crate::embedding::parse_legacy_model(&emb_cfg.model)
+        .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small);
 
     println!(
         "{:<20} {}d",
@@ -1017,8 +1016,11 @@ fn cmd_model_status() -> Result<()> {
     println!("{:<20} {}", style("Cache dir:").dim(), emb_cfg.cache_dir);
 
     let cache_path = expand_path(&emb_cfg.cache_dir);
-    let model_id = model_choice.model_id();
-    let folder_name = format!("models--{}", model_id.replace('/', "--"));
+    let model_code = model_choice.model_code();
+    let mut parts = model_code.splitn(2, '/');
+    let org = parts.next().unwrap_or("");
+    let repo = parts.next().unwrap_or("");
+    let folder_name = format!("models--{org}--{repo}");
     let model_dir = cache_path.join(folder_name);
 
     println!();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -818,10 +818,7 @@ fn cmd_model_download() -> Result<()> {
 
         let cfg = load_config().embedding_config_with_defaults();
         let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-            model: crate::embedding::parse_legacy_model(&cfg.model)
-                .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small)
-                .as_str()
-                .to_string(),
+            model: cfg.model.clone(),
             auto_download: true,
             cache_dir: cfg
                 .cache_dir
@@ -999,8 +996,7 @@ fn cmd_model_status() -> Result<()> {
         style(&emb_cfg.model).cyan()
     );
 
-    let model_choice = crate::embedding::parse_legacy_model(&emb_cfg.model)
-        .unwrap_or(crate::embedding::EmbeddingModel::MultilingualE5Small);
+    let model_choice = crate::embedding::resolve_model(&emb_cfg.model);
 
     println!(
         "{:<20} {}d",
@@ -1016,11 +1012,7 @@ fn cmd_model_status() -> Result<()> {
     println!("{:<20} {}", style("Cache dir:").dim(), emb_cfg.cache_dir);
 
     let cache_path = expand_path(&emb_cfg.cache_dir);
-    let model_code = model_choice.model_code();
-    let mut parts = model_code.splitn(2, '/');
-    let org = parts.next().unwrap_or("");
-    let repo = parts.next().unwrap_or("");
-    let folder_name = format!("models--{org}--{repo}");
+    let folder_name = format!("models--{}", model_choice.model_code().replace('/', "--"));
     let model_dir = cache_path.join(folder_name);
 
     println!();

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,7 +218,7 @@ impl Default for ServerConfig {
 
 #[cfg(feature = "embed")]
 fn default_embedding_model() -> String {
-    "ArcticEmbedXS".into()
+    "MultilingualE5Small".into()
 }
 
 #[cfg(feature = "embed")]

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -1,8 +1,9 @@
 //! Embedding service for hybrid search (embed feature)
 //!
-//! Uses fastembed-rs (ONNX Runtime) for local inference with lazy model
-//! download via HuggingFace Hub and LRU query caching. Graceful degradation
-//! ensures BM25-only search works even when models aren't ready.
+//! Uses llm-kernel for the model catalog (`EmbeddingModel`), LRU cache
+//! (`EmbeddingCache`), and metadata lookups. `FastEmbedSession` wraps
+//! `fastembed::TextEmbedding` directly for full prefix control — call sites
+//! handle query/doc prefixes manually.
 
 #[cfg(feature = "embed")]
 use std::path::{Path, PathBuf};
@@ -14,11 +15,14 @@ use std::time::{Duration, Instant};
 #[cfg(feature = "embed")]
 use anyhow::{Context, Result};
 #[cfg(feature = "embed")]
-use fastembed::EmbeddingModel as FastEmbedModel;
-#[cfg(feature = "embed")]
 use fastembed::TextEmbedding;
 #[cfg(feature = "embed")]
 use fastembed::TextInitOptions;
+#[cfg(feature = "embed")]
+use llm_kernel::embedding::EmbeddingCache;
+
+// Re-export EmbeddingModel from llm-kernel for downstream use.
+pub use llm_kernel::embedding::EmbeddingModel;
 
 // ---------------------------------------------------------------------------
 // ModelState
@@ -58,493 +62,44 @@ impl std::fmt::Display for ModelState {
 }
 
 // ---------------------------------------------------------------------------
-// EmbeddingModelChoice
+// Legacy model name parser
 // ---------------------------------------------------------------------------
 
-/// Supported embedding models via fastembed-rs (ONNX Runtime).
+/// Parse a model name, handling backward-compatible Arctic aliases.
 ///
-/// Config names are matched by `parse()`. Models prefixed with `Arctic` are
-/// backward-compatible aliases for the Snowflake Arctic Embed series.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum EmbeddingModelChoice {
-    // ── MiniLM ───────────────────────────────────────────────
-    AllMiniLML6V2,
-    AllMiniLML6V2Q,
-    AllMiniLML12V2,
-    AllMiniLML12V2Q,
-    // ── MPNet ────────────────────────────────────────────────
-    AllMpnetBaseV2,
-    // ── E5 multilingual ─────────────────────────────────────
-    MultilingualE5Small,
-    MultilingualE5Base,
-    MultilingualE5Large,
-    // ── BGE English ──────────────────────────────────────────
-    BGESmallENV15,
-    BGESmallENV15Q,
-    BGEBaseENV15,
-    BGEBaseENV15Q,
-    BGELargeENV15,
-    BGELargeENV15Q,
-    // ── BGE Chinese ──────────────────────────────────────────
-    BGESmallZHV15,
-    BGELargeZHV15,
-    // ── BGE Multilingual ────────────────────────────────────
-    BGEM3,
-    // ── ModernBERT ───────────────────────────────────────────
-    ModernBertEmbedLarge,
-    // ── Nomic ────────────────────────────────────────────────
-    NomicEmbedTextV1,
-    NomicEmbedTextV15,
-    NomicEmbedTextV15Q,
-    // ── Paraphrase multilingual ─────────────────────────────
-    ParaphraseMLMiniLML12V2,
-    ParaphraseMLMiniLML12V2Q,
-    ParaphraseMLMpnetBaseV2,
-    // ── MixedBread ───────────────────────────────────────────
-    MxbaiEmbedLargeV1,
-    MxbaiEmbedLargeV1Q,
-    // ── GTE ──────────────────────────────────────────────────
-    GTEBaseENV15,
-    GTEBaseENV15Q,
-    GTELargeENV15,
-    GTELargeENV15Q,
-    // ── Jina ─────────────────────────────────────────────────
-    JinaEmbeddingsV2BaseCode,
-    JinaEmbeddingsV2BaseEN,
-    // ── Gemma ────────────────────────────────────────────────
-    EmbeddingGemma300M,
-    // ── Snowflake Arctic (backward-compat aliases) ──────────
-    #[default]
-    ArcticEmbedXS,
-    ArcticEmbedXSQ,
-    ArcticEmbedS,
-    ArcticEmbedSQ,
-    ArcticEmbedM,
-    ArcticEmbedMQ,
-    ArcticEmbedMLong,
-    ArcticEmbedMLongQ,
-    ArcticEmbedL,
-    ArcticEmbedLQ,
-}
-
-impl EmbeddingModelChoice {
-    pub fn dimension(&self) -> usize {
-        match self {
-            Self::AllMiniLML6V2
-            | Self::AllMiniLML6V2Q
-            | Self::AllMiniLML12V2
-            | Self::AllMiniLML12V2Q
-            | Self::MultilingualE5Small
-            | Self::BGESmallENV15
-            | Self::BGESmallENV15Q
-            | Self::ParaphraseMLMiniLML12V2
-            | Self::ParaphraseMLMiniLML12V2Q
-            | Self::ArcticEmbedXS
-            | Self::ArcticEmbedXSQ
-            | Self::ArcticEmbedS
-            | Self::ArcticEmbedSQ => 384,
-
-            Self::BGESmallZHV15 => 512,
-
-            Self::AllMpnetBaseV2
-            | Self::MultilingualE5Base
-            | Self::BGEBaseENV15
-            | Self::BGEBaseENV15Q
-            | Self::NomicEmbedTextV1
-            | Self::NomicEmbedTextV15
-            | Self::NomicEmbedTextV15Q
-            | Self::ParaphraseMLMpnetBaseV2
-            | Self::GTEBaseENV15
-            | Self::GTEBaseENV15Q
-            | Self::JinaEmbeddingsV2BaseCode
-            | Self::JinaEmbeddingsV2BaseEN
-            | Self::EmbeddingGemma300M
-            | Self::ArcticEmbedM
-            | Self::ArcticEmbedMQ
-            | Self::ArcticEmbedMLong
-            | Self::ArcticEmbedMLongQ => 768,
-
-            Self::MultilingualE5Large
-            | Self::BGELargeENV15
-            | Self::BGELargeENV15Q
-            | Self::BGELargeZHV15
-            | Self::BGEM3
-            | Self::ModernBertEmbedLarge
-            | Self::MxbaiEmbedLargeV1
-            | Self::MxbaiEmbedLargeV1Q
-            | Self::GTELargeENV15
-            | Self::GTELargeENV15Q
-            | Self::ArcticEmbedL
-            | Self::ArcticEmbedLQ => 1024,
-        }
+/// New code should use `EmbeddingModel::parse()` directly. This function
+/// maps legacy names (e.g., `"ArcticEmbedXS"`) to their current equivalents
+/// (e.g., `EmbeddingModel::SnowflakeArcticEmbedXS`).
+pub fn parse_legacy_model(name: &str) -> Option<EmbeddingModel> {
+    // Try llm-kernel's case-insensitive parse first
+    if let Ok(model) = EmbeddingModel::parse(name) {
+        return Some(model);
     }
-
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "AllMiniLML6V2" => Some(Self::AllMiniLML6V2),
-            "AllMiniLML6V2Q" => Some(Self::AllMiniLML6V2Q),
-            "AllMiniLML12V2" => Some(Self::AllMiniLML12V2),
-            "AllMiniLML12V2Q" => Some(Self::AllMiniLML12V2Q),
-            "AllMpnetBaseV2" => Some(Self::AllMpnetBaseV2),
-            "MultilingualE5Small" => Some(Self::MultilingualE5Small),
-            "MultilingualE5Base" => Some(Self::MultilingualE5Base),
-            "MultilingualE5Large" => Some(Self::MultilingualE5Large),
-            "BGESmallENV15" => Some(Self::BGESmallENV15),
-            "BGESmallENV15Q" => Some(Self::BGESmallENV15Q),
-            "BGEBaseENV15" => Some(Self::BGEBaseENV15),
-            "BGEBaseENV15Q" => Some(Self::BGEBaseENV15Q),
-            "BGELargeENV15" => Some(Self::BGELargeENV15),
-            "BGELargeENV15Q" => Some(Self::BGELargeENV15Q),
-            "BGESmallZHV15" => Some(Self::BGESmallZHV15),
-            "BGELargeZHV15" => Some(Self::BGELargeZHV15),
-            "BGEM3" => Some(Self::BGEM3),
-            "ModernBertEmbedLarge" => Some(Self::ModernBertEmbedLarge),
-            "NomicEmbedTextV1" => Some(Self::NomicEmbedTextV1),
-            "NomicEmbedTextV15" => Some(Self::NomicEmbedTextV15),
-            "NomicEmbedTextV15Q" => Some(Self::NomicEmbedTextV15Q),
-            "ParaphraseMLMiniLML12V2" => Some(Self::ParaphraseMLMiniLML12V2),
-            "ParaphraseMLMiniLML12V2Q" => Some(Self::ParaphraseMLMiniLML12V2Q),
-            "ParaphraseMLMpnetBaseV2" => Some(Self::ParaphraseMLMpnetBaseV2),
-            "MxbaiEmbedLargeV1" => Some(Self::MxbaiEmbedLargeV1),
-            "MxbaiEmbedLargeV1Q" => Some(Self::MxbaiEmbedLargeV1Q),
-            "GTEBaseENV15" => Some(Self::GTEBaseENV15),
-            "GTEBaseENV15Q" => Some(Self::GTEBaseENV15Q),
-            "GTELargeENV15" => Some(Self::GTELargeENV15),
-            "GTELargeENV15Q" => Some(Self::GTELargeENV15Q),
-            "JinaEmbeddingsV2BaseCode" => Some(Self::JinaEmbeddingsV2BaseCode),
-            "JinaEmbeddingsV2BaseEN" => Some(Self::JinaEmbeddingsV2BaseEN),
-            "EmbeddingGemma300M" => Some(Self::EmbeddingGemma300M),
-            "ArcticEmbedXS" => Some(Self::ArcticEmbedXS),
-            "ArcticEmbedXSQ" => Some(Self::ArcticEmbedXSQ),
-            "ArcticEmbedS" => Some(Self::ArcticEmbedS),
-            "ArcticEmbedSQ" => Some(Self::ArcticEmbedSQ),
-            "ArcticEmbedM" => Some(Self::ArcticEmbedM),
-            "ArcticEmbedMQ" => Some(Self::ArcticEmbedMQ),
-            "ArcticEmbedMLong" => Some(Self::ArcticEmbedMLong),
-            "ArcticEmbedMLongQ" => Some(Self::ArcticEmbedMLongQ),
-            "ArcticEmbedL" => Some(Self::ArcticEmbedL),
-            "ArcticEmbedLQ" => Some(Self::ArcticEmbedLQ),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::AllMiniLML6V2 => "AllMiniLML6V2",
-            Self::AllMiniLML6V2Q => "AllMiniLML6V2Q",
-            Self::AllMiniLML12V2 => "AllMiniLML12V2",
-            Self::AllMiniLML12V2Q => "AllMiniLML12V2Q",
-            Self::AllMpnetBaseV2 => "AllMpnetBaseV2",
-            Self::MultilingualE5Small => "MultilingualE5Small",
-            Self::MultilingualE5Base => "MultilingualE5Base",
-            Self::MultilingualE5Large => "MultilingualE5Large",
-            Self::BGESmallENV15 => "BGESmallENV15",
-            Self::BGESmallENV15Q => "BGESmallENV15Q",
-            Self::BGEBaseENV15 => "BGEBaseENV15",
-            Self::BGEBaseENV15Q => "BGEBaseENV15Q",
-            Self::BGELargeENV15 => "BGELargeENV15",
-            Self::BGELargeENV15Q => "BGELargeENV15Q",
-            Self::BGESmallZHV15 => "BGESmallZHV15",
-            Self::BGELargeZHV15 => "BGELargeZHV15",
-            Self::BGEM3 => "BGEM3",
-            Self::ModernBertEmbedLarge => "ModernBertEmbedLarge",
-            Self::NomicEmbedTextV1 => "NomicEmbedTextV1",
-            Self::NomicEmbedTextV15 => "NomicEmbedTextV15",
-            Self::NomicEmbedTextV15Q => "NomicEmbedTextV15Q",
-            Self::ParaphraseMLMiniLML12V2 => "ParaphraseMLMiniLML12V2",
-            Self::ParaphraseMLMiniLML12V2Q => "ParaphraseMLMiniLML12V2Q",
-            Self::ParaphraseMLMpnetBaseV2 => "ParaphraseMLMpnetBaseV2",
-            Self::MxbaiEmbedLargeV1 => "MxbaiEmbedLargeV1",
-            Self::MxbaiEmbedLargeV1Q => "MxbaiEmbedLargeV1Q",
-            Self::GTEBaseENV15 => "GTEBaseENV15",
-            Self::GTEBaseENV15Q => "GTEBaseENV15Q",
-            Self::GTELargeENV15 => "GTELargeENV15",
-            Self::GTELargeENV15Q => "GTELargeENV15Q",
-            Self::JinaEmbeddingsV2BaseCode => "JinaEmbeddingsV2BaseCode",
-            Self::JinaEmbeddingsV2BaseEN => "JinaEmbeddingsV2BaseEN",
-            Self::EmbeddingGemma300M => "EmbeddingGemma300M",
-            Self::ArcticEmbedXS => "ArcticEmbedXS",
-            Self::ArcticEmbedXSQ => "ArcticEmbedXSQ",
-            Self::ArcticEmbedS => "ArcticEmbedS",
-            Self::ArcticEmbedSQ => "ArcticEmbedSQ",
-            Self::ArcticEmbedM => "ArcticEmbedM",
-            Self::ArcticEmbedMQ => "ArcticEmbedMQ",
-            Self::ArcticEmbedMLong => "ArcticEmbedMLong",
-            Self::ArcticEmbedMLongQ => "ArcticEmbedMLongQ",
-            Self::ArcticEmbedL => "ArcticEmbedL",
-            Self::ArcticEmbedLQ => "ArcticEmbedLQ",
-        }
-    }
-
-    /// Map to the corresponding fastembed EmbeddingModel variant.
-    #[cfg(feature = "embed")]
-    pub(crate) fn to_fastembed(self) -> FastEmbedModel {
-        match self {
-            Self::AllMiniLML6V2 => FastEmbedModel::AllMiniLML6V2,
-            Self::AllMiniLML6V2Q => FastEmbedModel::AllMiniLML6V2Q,
-            Self::AllMiniLML12V2 => FastEmbedModel::AllMiniLML12V2,
-            Self::AllMiniLML12V2Q => FastEmbedModel::AllMiniLML12V2Q,
-            Self::AllMpnetBaseV2 => FastEmbedModel::AllMpnetBaseV2,
-            Self::MultilingualE5Small => FastEmbedModel::MultilingualE5Small,
-            Self::MultilingualE5Base => FastEmbedModel::MultilingualE5Base,
-            Self::MultilingualE5Large => FastEmbedModel::MultilingualE5Large,
-            Self::BGESmallENV15 => FastEmbedModel::BGESmallENV15,
-            Self::BGESmallENV15Q => FastEmbedModel::BGESmallENV15Q,
-            Self::BGEBaseENV15 => FastEmbedModel::BGEBaseENV15,
-            Self::BGEBaseENV15Q => FastEmbedModel::BGEBaseENV15Q,
-            Self::BGELargeENV15 => FastEmbedModel::BGELargeENV15,
-            Self::BGELargeENV15Q => FastEmbedModel::BGELargeENV15Q,
-            Self::BGESmallZHV15 => FastEmbedModel::BGESmallZHV15,
-            Self::BGELargeZHV15 => FastEmbedModel::BGELargeZHV15,
-            Self::BGEM3 => FastEmbedModel::BGEM3,
-            Self::ModernBertEmbedLarge => FastEmbedModel::ModernBertEmbedLarge,
-            Self::NomicEmbedTextV1 => FastEmbedModel::NomicEmbedTextV1,
-            Self::NomicEmbedTextV15 => FastEmbedModel::NomicEmbedTextV15,
-            Self::NomicEmbedTextV15Q => FastEmbedModel::NomicEmbedTextV15Q,
-            Self::ParaphraseMLMiniLML12V2 => FastEmbedModel::ParaphraseMLMiniLML12V2,
-            Self::ParaphraseMLMiniLML12V2Q => FastEmbedModel::ParaphraseMLMiniLML12V2Q,
-            Self::ParaphraseMLMpnetBaseV2 => FastEmbedModel::ParaphraseMLMpnetBaseV2,
-            Self::MxbaiEmbedLargeV1 => FastEmbedModel::MxbaiEmbedLargeV1,
-            Self::MxbaiEmbedLargeV1Q => FastEmbedModel::MxbaiEmbedLargeV1Q,
-            Self::GTEBaseENV15 => FastEmbedModel::GTEBaseENV15,
-            Self::GTEBaseENV15Q => FastEmbedModel::GTEBaseENV15Q,
-            Self::GTELargeENV15 => FastEmbedModel::GTELargeENV15,
-            Self::GTELargeENV15Q => FastEmbedModel::GTELargeENV15Q,
-            Self::JinaEmbeddingsV2BaseCode => FastEmbedModel::JinaEmbeddingsV2BaseCode,
-            Self::JinaEmbeddingsV2BaseEN => FastEmbedModel::JinaEmbeddingsV2BaseEN,
-            Self::EmbeddingGemma300M => FastEmbedModel::EmbeddingGemma300M,
-            // Arctic backward-compat aliases → Snowflake fastembed variants
-            Self::ArcticEmbedXS => FastEmbedModel::SnowflakeArcticEmbedXS,
-            Self::ArcticEmbedXSQ => FastEmbedModel::SnowflakeArcticEmbedXSQ,
-            Self::ArcticEmbedS => FastEmbedModel::SnowflakeArcticEmbedS,
-            Self::ArcticEmbedSQ => FastEmbedModel::SnowflakeArcticEmbedSQ,
-            Self::ArcticEmbedM => FastEmbedModel::SnowflakeArcticEmbedM,
-            Self::ArcticEmbedMQ => FastEmbedModel::SnowflakeArcticEmbedMQ,
-            Self::ArcticEmbedMLong => FastEmbedModel::SnowflakeArcticEmbedMLong,
-            Self::ArcticEmbedMLongQ => FastEmbedModel::SnowflakeArcticEmbedMLongQ,
-            Self::ArcticEmbedL => FastEmbedModel::SnowflakeArcticEmbedL,
-            Self::ArcticEmbedLQ => FastEmbedModel::SnowflakeArcticEmbedLQ,
-        }
-    }
-
-    pub fn query_prefix(self) -> Option<&'static str> {
-        match self {
-            Self::MultilingualE5Small | Self::MultilingualE5Base | Self::MultilingualE5Large => {
-                Some("query: ")
-            }
-
-            Self::NomicEmbedTextV15 | Self::NomicEmbedTextV15Q => Some("search_query: "),
-
-            Self::ArcticEmbedXS
-            | Self::ArcticEmbedXSQ
-            | Self::ArcticEmbedS
-            | Self::ArcticEmbedSQ
-            | Self::ArcticEmbedM
-            | Self::ArcticEmbedMQ
-            | Self::ArcticEmbedMLong
-            | Self::ArcticEmbedMLongQ
-            | Self::ArcticEmbedL
-            | Self::ArcticEmbedLQ => {
-                Some("Represent this sentence for searching relevant passages: ")
-            }
-
-            _ => None,
-        }
-    }
-
-    pub fn doc_prefix(self) -> Option<&'static str> {
-        match self {
-            Self::MultilingualE5Small | Self::MultilingualE5Base | Self::MultilingualE5Large => {
-                Some("passage: ")
-            }
-
-            Self::NomicEmbedTextV15 | Self::NomicEmbedTextV15Q => Some("search_document: "),
-
-            _ => None,
-        }
-    }
-
-    /// Maximum sequence length (tokens) supported by the model.
-    pub fn max_seq_length(self) -> usize {
-        match self {
-            Self::AllMiniLML6V2
-            | Self::AllMiniLML6V2Q
-            | Self::AllMiniLML12V2
-            | Self::AllMiniLML12V2Q => 256,
-
-            Self::AllMpnetBaseV2 => 384,
-
-            // Arctic Embed non-Long variants: 512 token limit
-            Self::ArcticEmbedXS
-            | Self::ArcticEmbedXSQ
-            | Self::ArcticEmbedS
-            | Self::ArcticEmbedSQ
-            | Self::ArcticEmbedM
-            | Self::ArcticEmbedMQ
-            | Self::ArcticEmbedL
-            | Self::ArcticEmbedLQ => 512,
-
-            // Long-context models
-            Self::BGEM3
-            | Self::NomicEmbedTextV1
-            | Self::NomicEmbedTextV15
-            | Self::NomicEmbedTextV15Q
-            | Self::JinaEmbeddingsV2BaseCode
-            | Self::JinaEmbeddingsV2BaseEN
-            | Self::EmbeddingGemma300M
-            | Self::ArcticEmbedMLong
-            | Self::ArcticEmbedMLongQ => 8192,
-
-            // All others default to 512
-            _ => 512,
-        }
-    }
-
-    /// Approximate model size in MB (ONNX format estimates).
-    pub fn size_mb(&self) -> usize {
-        match self {
-            Self::AllMiniLML6V2 | Self::AllMiniLML6V2Q => 80,
-            Self::AllMiniLML12V2 | Self::AllMiniLML12V2Q => 120,
-            Self::AllMpnetBaseV2 => 420,
-            Self::MultilingualE5Small => 470,
-            Self::MultilingualE5Base => 1100,
-            Self::MultilingualE5Large => 2200,
-            Self::BGESmallENV15 => 130,
-            Self::BGESmallENV15Q => 40,
-            Self::BGEBaseENV15 => 430,
-            Self::BGEBaseENV15Q => 130,
-            Self::BGELargeENV15 => 1300,
-            Self::BGELargeENV15Q => 400,
-            Self::BGESmallZHV15 => 100,
-            Self::BGELargeZHV15 => 1300,
-            Self::BGEM3 => 600,
-            Self::ModernBertEmbedLarge => 600,
-            Self::NomicEmbedTextV1 => 550,
-            Self::NomicEmbedTextV15 | Self::NomicEmbedTextV15Q => 550,
-            Self::ParaphraseMLMiniLML12V2 => 420,
-            Self::ParaphraseMLMiniLML12V2Q => 130,
-            Self::ParaphraseMLMpnetBaseV2 => 1100,
-            Self::MxbaiEmbedLargeV1 => 670,
-            Self::MxbaiEmbedLargeV1Q => 200,
-            Self::GTEBaseENV15 => 430,
-            Self::GTEBaseENV15Q => 130,
-            Self::GTELargeENV15 => 1300,
-            Self::GTELargeENV15Q => 400,
-            Self::JinaEmbeddingsV2BaseCode => 550,
-            Self::JinaEmbeddingsV2BaseEN => 550,
-            Self::EmbeddingGemma300M => 600,
-            Self::ArcticEmbedXS | Self::ArcticEmbedXSQ => 90,
-            Self::ArcticEmbedS | Self::ArcticEmbedSQ => 130,
-            Self::ArcticEmbedM
-            | Self::ArcticEmbedMQ
-            | Self::ArcticEmbedMLong
-            | Self::ArcticEmbedMLongQ => 430,
-            Self::ArcticEmbedL | Self::ArcticEmbedLQ => 1300,
-        }
-    }
-
-    /// HuggingFace model repo ID for cache management.
-    pub fn model_id(self) -> &'static str {
-        match self {
-            Self::AllMiniLML6V2 => "Qdrant/all-MiniLM-L6-v2-onnx",
-            Self::AllMiniLML6V2Q => "Xenova/all-MiniLM-L6-v2",
-            Self::AllMiniLML12V2 => "Xenova/all-MiniLM-L12-v2",
-            Self::AllMiniLML12V2Q => "Qdrant/all-MiniLM-L12-v2-onnx-Q",
-            Self::AllMpnetBaseV2 => "Xenova/all-mpnet-base-v2",
-            Self::MultilingualE5Small => "intfloat/multilingual-e5-small",
-            Self::MultilingualE5Base => "intfloat/multilingual-e5-base",
-            Self::MultilingualE5Large => "Qdrant/multilingual-e5-large-onnx",
-            Self::BGESmallENV15 => "Xenova/bge-small-en-v1.5",
-            Self::BGESmallENV15Q => "Qdrant/bge-small-en-v1.5-onnx-Q",
-            Self::BGEBaseENV15 => "Xenova/bge-base-en-v1.5",
-            Self::BGEBaseENV15Q => "Qdrant/bge-base-en-v1.5-onnx-Q",
-            Self::BGELargeENV15 => "Xenova/bge-large-en-v1.5",
-            Self::BGELargeENV15Q => "Qdrant/bge-large-en-v1.5-onnx-Q",
-            Self::BGESmallZHV15 => "Xenova/bge-small-zh-v1.5",
-            Self::BGELargeZHV15 => "Xenova/bge-large-zh-v1.5",
-            Self::BGEM3 => "BAAI/bge-m3",
-            Self::ModernBertEmbedLarge => "lightonai/modernbert-embed-large",
-            Self::NomicEmbedTextV1 => "nomic-ai/nomic-embed-text-v1",
-            Self::NomicEmbedTextV15 => "nomic-ai/nomic-embed-text-v1.5",
-            Self::NomicEmbedTextV15Q => "nomic-ai/nomic-embed-text-v1.5",
-            Self::ParaphraseMLMiniLML12V2 => "Xenova/paraphrase-multilingual-MiniLM-L12-v2",
-            Self::ParaphraseMLMiniLML12V2Q => "Qdrant/paraphrase-multilingual-MiniLM-L12-v2-onnx-Q",
-            Self::ParaphraseMLMpnetBaseV2 => "Xenova/paraphrase-multilingual-mpnet-base-v2",
-            Self::MxbaiEmbedLargeV1 => "mixedbread-ai/mxbai-embed-large-v1",
-            Self::MxbaiEmbedLargeV1Q => "Qdrant/mxbai-embed-large-v1-onnx-Q",
-            Self::GTEBaseENV15 => "Alibaba-NLP/gte-base-en-v1.5",
-            Self::GTEBaseENV15Q => "Qdrant/gte-base-en-v1.5-onnx-Q",
-            Self::GTELargeENV15 => "Alibaba-NLP/gte-large-en-v1.5",
-            Self::GTELargeENV15Q => "Qdrant/gte-large-en-v1.5-onnx-Q",
-            Self::JinaEmbeddingsV2BaseCode => "jinaai/jina-embeddings-v2-base-code",
-            Self::JinaEmbeddingsV2BaseEN => "jinaai/jina-embeddings-v2-base-en",
-            Self::EmbeddingGemma300M => "onnx-community/embeddinggemma-300m-ONNX",
-            Self::ArcticEmbedXS | Self::ArcticEmbedXSQ => "snowflake/snowflake-arctic-embed-xs",
-            Self::ArcticEmbedS | Self::ArcticEmbedSQ => "snowflake/snowflake-arctic-embed-s",
-            Self::ArcticEmbedM | Self::ArcticEmbedMQ => "Snowflake/snowflake-arctic-embed-m",
-            Self::ArcticEmbedMLong | Self::ArcticEmbedMLongQ => {
-                "snowflake/snowflake-arctic-embed-m-long"
-            }
-            Self::ArcticEmbedL | Self::ArcticEmbedLQ => "snowflake/snowflake-arctic-embed-l",
-        }
-    }
-}
-
-impl std::fmt::Display for EmbeddingModelChoice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", (*self).as_str())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// LRU cache backed by IndexMap
-// ---------------------------------------------------------------------------
-
-pub struct QueryEmbedCache {
-    capacity: usize,
-    map: indexmap::IndexMap<String, Vec<f32>>,
-}
-
-impl QueryEmbedCache {
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            capacity,
-            map: indexmap::IndexMap::new(),
-        }
-    }
-
-    pub fn get(&mut self, key: &str) -> Option<&Vec<f32>> {
-        if self.capacity == 0 {
-            return None;
-        }
-        if let Some((k, v)) = self.map.shift_remove_entry(key) {
-            self.map.insert(k, v);
-            self.map.get(key)
-        } else {
-            None
-        }
-    }
-
-    pub fn insert(&mut self, key: String, value: Vec<f32>) {
-        if self.capacity == 0 {
-            return;
-        }
-        if let Some((k, _)) = self.map.shift_remove_entry(&key) {
-            self.map.insert(k, value);
-        } else {
-            if self.map.len() >= self.capacity {
-                self.map.shift_remove_index(0);
-            }
-            self.map.insert(key, value);
-        }
-    }
+    // Legacy Arctic aliases (old alcove names → Snowflake-prefixed variants)
+    let legacy = match name {
+        "ArcticEmbedXS" => EmbeddingModel::SnowflakeArcticEmbedXS,
+        "ArcticEmbedXSQ" => EmbeddingModel::SnowflakeArcticEmbedXSQ,
+        "ArcticEmbedS" => EmbeddingModel::SnowflakeArcticEmbedS,
+        "ArcticEmbedSQ" => EmbeddingModel::SnowflakeArcticEmbedSQ,
+        "ArcticEmbedM" => EmbeddingModel::SnowflakeArcticEmbedM,
+        "ArcticEmbedMQ" => EmbeddingModel::SnowflakeArcticEmbedMQ,
+        "ArcticEmbedMLong" => EmbeddingModel::SnowflakeArcticEmbedMLong,
+        "ArcticEmbedMLongQ" => EmbeddingModel::SnowflakeArcticEmbedMLongQ,
+        "ArcticEmbedL" => EmbeddingModel::SnowflakeArcticEmbedL,
+        "ArcticEmbedLQ" => EmbeddingModel::SnowflakeArcticEmbedLQ,
+        _ => return None,
+    };
+    Some(legacy)
 }
 
 // ---------------------------------------------------------------------------
 // FastEmbed session (ONNX Runtime inference engine)
 // ---------------------------------------------------------------------------
 
-/// Holds a loaded fastembed TextEmbedding, ready for inference.
+/// Holds a loaded fastembed `TextEmbedding`, ready for inference.
+///
+/// Wraps `TextEmbedding` directly (not via llm-kernel's `FastembedProvider`)
+/// to retain full prefix control — call sites handle query/doc prefixes.
 #[cfg(feature = "embed")]
 struct FastEmbedSession {
     model: TextEmbedding,
@@ -554,9 +109,9 @@ struct FastEmbedSession {
 impl FastEmbedSession {
     /// Download model (if needed) via fastembed's HuggingFace Hub integration
     /// and build an ONNX Runtime session.
-    fn load(choice: &EmbeddingModelChoice, cache_dir: &Path) -> Result<Self> {
+    fn load(model: EmbeddingModel, cache_dir: &Path) -> Result<Self> {
         #[allow(unused_mut)]
-        let mut opts = TextInitOptions::new(choice.to_fastembed())
+        let mut opts = TextInitOptions::new(model.as_fastembed())
             .with_cache_dir(cache_dir.to_path_buf())
             .with_show_download_progress(true);
 
@@ -576,8 +131,7 @@ impl FastEmbedSession {
 
     /// Embed a batch of texts, returning one normalized Vec<f32> per text.
     fn embed_batch(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        // fastembed's embed() already L2-normalizes via output::transformer_with_precedence
-        // (see fastembed src/text_embedding/output.rs — normalize() per row).
+        // fastembed's embed() already L2-normalizes
         self.model.embed(texts, None)
     }
 }
@@ -595,12 +149,12 @@ pub struct EmbeddingService {
     #[allow(dead_code)]
     previous_dimension: Arc<Mutex<Option<usize>>>,
     last_embed_at: Arc<Mutex<Instant>>,
-    query_cache: Arc<Mutex<QueryEmbedCache>>,
+    query_cache: Arc<Mutex<EmbeddingCache>>,
 }
 
 #[cfg(feature = "embed")]
 struct InternalEmbeddingConfig {
-    model: EmbeddingModelChoice,
+    model: EmbeddingModel,
     cache_dir: PathBuf,
     enabled: bool,
 }
@@ -608,9 +162,9 @@ struct InternalEmbeddingConfig {
 #[cfg(feature = "embed")]
 impl EmbeddingService {
     pub fn new(config: crate::config::EmbeddingConfig) -> Self {
-        let model_choice = EmbeddingModelChoice::parse(&config.model).unwrap_or_else(|| {
+        let model_choice = parse_legacy_model(&config.model).unwrap_or_else(|| {
             eprintln!("Warning: Unknown model '{}', using default", config.model);
-            EmbeddingModelChoice::default()
+            EmbeddingModel::MultilingualE5Small
         });
 
         let enabled = config.enabled;
@@ -623,7 +177,7 @@ impl EmbeddingService {
 
         let initial_state = if !enabled {
             ModelState::Disabled
-        } else if Self::is_model_cached(model_choice, &cache_dir) {
+        } else if llm_kernel::embedding::is_model_cached(model_choice, &cache_dir) {
             ModelState::Cached
         } else {
             ModelState::NotLoaded
@@ -636,7 +190,7 @@ impl EmbeddingService {
             session: Arc::new(Mutex::new(None)),
             previous_dimension: Arc::new(Mutex::new(None)),
             last_embed_at: Arc::new(Mutex::new(Instant::now())),
-            query_cache: Arc::new(Mutex::new(QueryEmbedCache::new(config.query_cache_size))),
+            query_cache: Arc::new(Mutex::new(EmbeddingCache::new(config.query_cache_size))),
         }
     }
 
@@ -752,7 +306,7 @@ impl EmbeddingService {
                         return;
                     }
 
-                    match FastEmbedSession::load(&model, &cache_dir) {
+                    match FastEmbedSession::load(model, &cache_dir) {
                         Ok(session) => {
                             let mut state_guard =
                                 state_arc.lock().unwrap_or_else(|e| e.into_inner());
@@ -856,19 +410,15 @@ impl EmbeddingService {
         Ok(results.into_iter().flatten().collect())
     }
 
-    /// Check if model weights are present in the HuggingFace Hub cache directory.
-    fn is_model_cached(model: EmbeddingModelChoice, cache_dir: &Path) -> bool {
-        let model_id = model.model_id();
-        let folder_name = format!("models--{}", model_id.replace('/', "--"));
-        cache_dir.join(folder_name).exists()
-    }
-
     #[allow(dead_code)]
     pub fn remove_cache(&self) -> std::result::Result<(), String> {
         // hf-hub cache uses "models--{org}--{repo}" folder naming.
-        // Remove only this model's folder so other cached models are unaffected.
-        let model_id = self.internal_config.model.model_id();
-        let folder_name = format!("models--{}", model_id.replace('/', "--"));
+        // Use model_code() which matches the actual HF repo used by fastembed-rs.
+        let model_code = self.internal_config.model.model_code();
+        let mut parts = model_code.splitn(2, '/');
+        let org = parts.next().unwrap_or("");
+        let repo = parts.next().unwrap_or("");
+        let folder_name = format!("models--{org}--{repo}");
         let model_dir = self.internal_config.cache_dir.join(folder_name);
         if model_dir.exists() {
             std::fs::remove_dir_all(&model_dir)
@@ -892,7 +442,7 @@ impl EmbeddingService {
         self.internal_config.model.as_str()
     }
 
-    pub fn model_choice(&self) -> EmbeddingModelChoice {
+    pub fn model_choice(&self) -> EmbeddingModel {
         self.internal_config.model
     }
 }
@@ -910,17 +460,17 @@ mod tests {
     fn test_model_choice_dimension() {
         #[cfg(feature = "embed")]
         {
-            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.dimension(), 384);
-            assert_eq!(EmbeddingModelChoice::MultilingualE5Small.dimension(), 384);
-            assert_eq!(EmbeddingModelChoice::MultilingualE5Base.dimension(), 768);
-            assert_eq!(EmbeddingModelChoice::MultilingualE5Large.dimension(), 1024);
-            assert_eq!(EmbeddingModelChoice::BGEM3.dimension(), 1024);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedXS.dimension(), 384);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedS.dimension(), 384);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedM.dimension(), 768);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedL.dimension(), 1024);
-            assert_eq!(EmbeddingModelChoice::BGESmallZHV15.dimension(), 512);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedMLong.dimension(), 768);
+            assert_eq!(EmbeddingModel::AllMiniLML6V2.dimension(), 384);
+            assert_eq!(EmbeddingModel::MultilingualE5Small.dimension(), 384);
+            assert_eq!(EmbeddingModel::MultilingualE5Base.dimension(), 768);
+            assert_eq!(EmbeddingModel::MultilingualE5Large.dimension(), 1024);
+            assert_eq!(EmbeddingModel::BGEM3.dimension(), 1024);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedXS.dimension(), 384);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedS.dimension(), 384);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedM.dimension(), 768);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedL.dimension(), 1024);
+            assert_eq!(EmbeddingModel::BGESmallZHV15.dimension(), 512);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedMLong.dimension(), 768);
         }
     }
 
@@ -928,51 +478,18 @@ mod tests {
     fn test_model_max_seq_length() {
         #[cfg(feature = "embed")]
         {
-            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.max_seq_length(), 256);
-            assert_eq!(EmbeddingModelChoice::AllMpnetBaseV2.max_seq_length(), 384);
-            // Arctic non-Long: 512
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedXS.max_seq_length(), 512);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedS.max_seq_length(), 512);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedM.max_seq_length(), 512);
-            assert_eq!(EmbeddingModelChoice::ArcticEmbedL.max_seq_length(), 512);
-            // Arctic Long: 8192
+            assert_eq!(EmbeddingModel::AllMiniLML6V2.max_seq_length(), 256);
+            assert_eq!(EmbeddingModel::AllMpnetBaseV2.max_seq_length(), 384);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedXS.max_seq_length(), 512);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedS.max_seq_length(), 512);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedM.max_seq_length(), 512);
+            assert_eq!(EmbeddingModel::SnowflakeArcticEmbedL.max_seq_length(), 512);
             assert_eq!(
-                EmbeddingModelChoice::ArcticEmbedMLong.max_seq_length(),
+                EmbeddingModel::SnowflakeArcticEmbedMLong.max_seq_length(),
                 8192
             );
-            assert_eq!(EmbeddingModelChoice::BGEM3.max_seq_length(), 8192);
-            assert_eq!(
-                EmbeddingModelChoice::NomicEmbedTextV15.max_seq_length(),
-                8192
-            );
-        }
-    }
-
-    #[test]
-    fn test_model_id_uniqueness() {
-        #[cfg(feature = "embed")]
-        {
-            // Verify quantized variants have distinct model IDs from non-Q counterparts
-            for (a, b) in [
-                (
-                    EmbeddingModelChoice::AllMiniLML12V2,
-                    EmbeddingModelChoice::AllMiniLML12V2Q,
-                ),
-                (
-                    EmbeddingModelChoice::GTEBaseENV15,
-                    EmbeddingModelChoice::GTEBaseENV15Q,
-                ),
-                (
-                    EmbeddingModelChoice::GTELargeENV15,
-                    EmbeddingModelChoice::GTELargeENV15Q,
-                ),
-                (
-                    EmbeddingModelChoice::MxbaiEmbedLargeV1,
-                    EmbeddingModelChoice::MxbaiEmbedLargeV1Q,
-                ),
-            ] {
-                assert_ne!(a.model_id(), b.model_id(), "{a:?} and {b:?} share model_id");
-            }
+            assert_eq!(EmbeddingModel::BGEM3.max_seq_length(), 8192);
+            assert_eq!(EmbeddingModel::NomicEmbedTextV15.max_seq_length(), 8192);
         }
     }
 
@@ -980,36 +497,36 @@ mod tests {
     fn test_model_prefixes() {
         #[cfg(feature = "embed")]
         {
-            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.query_prefix(), None);
-            assert_eq!(EmbeddingModelChoice::AllMiniLML6V2.doc_prefix(), None);
+            assert_eq!(EmbeddingModel::AllMiniLML6V2.query_prefix(), None);
+            assert_eq!(EmbeddingModel::AllMiniLML6V2.doc_prefix(), None);
 
             for m in [
-                EmbeddingModelChoice::MultilingualE5Small,
-                EmbeddingModelChoice::MultilingualE5Base,
-                EmbeddingModelChoice::MultilingualE5Large,
+                EmbeddingModel::MultilingualE5Small,
+                EmbeddingModel::MultilingualE5Base,
+                EmbeddingModel::MultilingualE5Large,
             ] {
                 assert_eq!(m.query_prefix(), Some("query: "), "{:?} query prefix", m);
                 assert_eq!(m.doc_prefix(), Some("passage: "), "{:?} doc prefix", m);
             }
 
-            assert_eq!(EmbeddingModelChoice::BGEM3.query_prefix(), None);
-            assert_eq!(EmbeddingModelChoice::BGEM3.doc_prefix(), None);
+            assert_eq!(EmbeddingModel::BGEM3.query_prefix(), None);
+            assert_eq!(EmbeddingModel::BGEM3.doc_prefix(), None);
 
             assert_eq!(
-                EmbeddingModelChoice::NomicEmbedTextV15.query_prefix(),
+                EmbeddingModel::NomicEmbedTextV15.query_prefix(),
                 Some("search_query: ")
             );
             assert_eq!(
-                EmbeddingModelChoice::NomicEmbedTextV15.doc_prefix(),
+                EmbeddingModel::NomicEmbedTextV15.doc_prefix(),
                 Some("search_document: ")
             );
 
             let arctic_query_prefix = "Represent this sentence for searching relevant passages: ";
             for m in [
-                EmbeddingModelChoice::ArcticEmbedXS,
-                EmbeddingModelChoice::ArcticEmbedS,
-                EmbeddingModelChoice::ArcticEmbedM,
-                EmbeddingModelChoice::ArcticEmbedL,
+                EmbeddingModel::SnowflakeArcticEmbedXS,
+                EmbeddingModel::SnowflakeArcticEmbedS,
+                EmbeddingModel::SnowflakeArcticEmbedM,
+                EmbeddingModel::SnowflakeArcticEmbedL,
             ] {
                 assert_eq!(
                     m.query_prefix(),
@@ -1023,37 +540,34 @@ mod tests {
     }
 
     #[test]
-    fn test_model_choice_parse() {
+    fn test_parse_legacy_model() {
         #[cfg(feature = "embed")]
         {
-            // Backward compat names
+            // New names work directly
             assert_eq!(
-                EmbeddingModelChoice::parse("AllMiniLML6V2"),
-                Some(EmbeddingModelChoice::AllMiniLML6V2)
+                parse_legacy_model("AllMiniLML6V2"),
+                Some(EmbeddingModel::AllMiniLML6V2)
+            );
+            assert_eq!(parse_legacy_model("BGEM3"), Some(EmbeddingModel::BGEM3));
+            assert_eq!(
+                parse_legacy_model("SnowflakeArcticEmbedXS"),
+                Some(EmbeddingModel::SnowflakeArcticEmbedXS)
+            );
+            // Legacy Arctic aliases
+            assert_eq!(
+                parse_legacy_model("ArcticEmbedXS"),
+                Some(EmbeddingModel::SnowflakeArcticEmbedXS)
             );
             assert_eq!(
-                EmbeddingModelChoice::parse("BGEM3"),
-                Some(EmbeddingModelChoice::BGEM3)
+                parse_legacy_model("ArcticEmbedL"),
+                Some(EmbeddingModel::SnowflakeArcticEmbedL)
             );
             assert_eq!(
-                EmbeddingModelChoice::parse("ArcticEmbedXS"),
-                Some(EmbeddingModelChoice::ArcticEmbedXS)
-            );
-            assert_eq!(
-                EmbeddingModelChoice::parse("ArcticEmbedL"),
-                Some(EmbeddingModelChoice::ArcticEmbedL)
-            );
-            // New models
-            assert_eq!(
-                EmbeddingModelChoice::parse("BGESmallENV15"),
-                Some(EmbeddingModelChoice::BGESmallENV15)
-            );
-            assert_eq!(
-                EmbeddingModelChoice::parse("NomicEmbedTextV15"),
-                Some(EmbeddingModelChoice::NomicEmbedTextV15)
+                parse_legacy_model("ArcticEmbedMLong"),
+                Some(EmbeddingModel::SnowflakeArcticEmbedMLong)
             );
             // Unknown
-            assert_eq!(EmbeddingModelChoice::parse("InvalidModel"), None);
+            assert_eq!(parse_legacy_model("InvalidModel"), None);
         }
     }
 
@@ -1073,8 +587,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "embed")]
     fn test_embedding_cache_hit_skips_inference() {
-        let mut cache = super::QueryEmbedCache::new(2);
+        let mut cache = EmbeddingCache::new(2);
         assert!(cache.get("hello").is_none());
         cache.insert("hello".to_string(), vec![1.0, 2.0]);
         assert_eq!(cache.get("hello"), Some(&vec![1.0, 2.0]));
@@ -1091,8 +606,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "embed")]
     fn test_embedding_cache_lru_order() {
-        let mut cache = super::QueryEmbedCache::new(2);
+        let mut cache = EmbeddingCache::new(2);
         cache.insert("a".to_string(), vec![1.0]);
         cache.insert("b".to_string(), vec![2.0]);
         let _ = cache.get("a");

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -65,6 +65,9 @@ impl std::fmt::Display for ModelState {
 // Legacy model name parser
 // ---------------------------------------------------------------------------
 
+/// Default model used when parsing fails.
+const DEFAULT_MODEL: EmbeddingModel = EmbeddingModel::MultilingualE5Small;
+
 /// Parse a model name, handling backward-compatible Arctic aliases.
 ///
 /// New code should use `EmbeddingModel::parse()` directly. This function
@@ -90,6 +93,23 @@ pub fn parse_legacy_model(name: &str) -> Option<EmbeddingModel> {
         _ => return None,
     };
     Some(legacy)
+}
+
+/// Resolve a model name with fallback to the default.
+///
+/// Single entry-point for all call sites — avoids duplicating
+/// `parse_legacy_model().unwrap_or(DEFAULT_MODEL)` everywhere.
+pub fn resolve_model(name: &str) -> EmbeddingModel {
+    parse_legacy_model(name).unwrap_or(DEFAULT_MODEL)
+}
+
+/// Build the HuggingFace Hub cache folder name for a model.
+///
+/// Uses `model_code()` (the actual download repo) rather than the canonical
+/// model name, matching the folder layout created by `hf-hub`.
+#[cfg(feature = "embed")]
+fn hf_cache_folder(model: EmbeddingModel) -> String {
+    format!("models--{}", model.model_code().replace('/', "--"))
 }
 
 // ---------------------------------------------------------------------------
@@ -162,10 +182,16 @@ struct InternalEmbeddingConfig {
 #[cfg(feature = "embed")]
 impl EmbeddingService {
     pub fn new(config: crate::config::EmbeddingConfig) -> Self {
-        let model_choice = parse_legacy_model(&config.model).unwrap_or_else(|| {
-            eprintln!("Warning: Unknown model '{}', using default", config.model);
-            EmbeddingModel::MultilingualE5Small
-        });
+        let model_choice = resolve_model(&config.model);
+        if parse_legacy_model(&config.model).is_none() {
+            eprintln!(
+                "Warning: Unknown model '{}', using {} ({}d). \
+                 Run 'alcove index' to rebuild the vector index if you changed models.",
+                config.model,
+                model_choice.as_str(),
+                model_choice.dimension()
+            );
+        }
 
         let enabled = config.enabled;
         let cache_dir = PathBuf::from(&config.cache_dir);
@@ -412,13 +438,7 @@ impl EmbeddingService {
 
     #[allow(dead_code)]
     pub fn remove_cache(&self) -> std::result::Result<(), String> {
-        // hf-hub cache uses "models--{org}--{repo}" folder naming.
-        // Use model_code() which matches the actual HF repo used by fastembed-rs.
-        let model_code = self.internal_config.model.model_code();
-        let mut parts = model_code.splitn(2, '/');
-        let org = parts.next().unwrap_or("");
-        let repo = parts.next().unwrap_or("");
-        let folder_name = format!("models--{org}--{repo}");
+        let folder_name = hf_cache_folder(self.internal_config.model);
         let model_dir = self.internal_config.cache_dir.join(folder_name);
         if model_dir.exists() {
             std::fs::remove_dir_all(&model_dir)

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -182,16 +182,20 @@ struct InternalEmbeddingConfig {
 #[cfg(feature = "embed")]
 impl EmbeddingService {
     pub fn new(config: crate::config::EmbeddingConfig) -> Self {
-        let model_choice = resolve_model(&config.model);
-        if parse_legacy_model(&config.model).is_none() {
-            eprintln!(
-                "Warning: Unknown model '{}', using {} ({}d). \
-                 Run 'alcove index' to rebuild the vector index if you changed models.",
-                config.model,
-                model_choice.as_str(),
-                model_choice.dimension()
-            );
-        }
+        let model_choice = match parse_legacy_model(&config.model) {
+            Some(m) => m,
+            None => {
+                let default = DEFAULT_MODEL;
+                eprintln!(
+                    "Warning: Unknown model '{}', using {} ({}d). \
+                     Run 'alcove index' to rebuild the vector index if you changed models.",
+                    config.model,
+                    default.as_str(),
+                    default.dimension()
+                );
+                default
+            }
+        };
 
         let enabled = config.enabled;
         let cache_dir = PathBuf::from(&config.cache_dir);

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -760,7 +760,7 @@ fn run_full_vector_indexing(
     files_to_index: Vec<ProjectFile>,
 ) -> Result<(String, u64, u64, String)> {
     use crate::config::{effective_config, load_config};
-    use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
+    use crate::embedding::{EmbeddingService, resolve_model};
     use crate::vector::VectorStore;
 
     let cfg = load_config();
@@ -769,9 +769,9 @@ fn run_full_vector_indexing(
         return Ok(("disabled".to_string(), 0, 0, String::new()));
     }
 
-    let model = parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
+    let model = resolve_model(&emb_cfg.model);
     let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-        model: model.as_str().to_string(),
+        model: emb_cfg.model.clone(),
         auto_download: emb_cfg.auto_download,
         cache_dir: emb_cfg.cache_dir.clone(),
         enabled: true,
@@ -1051,18 +1051,17 @@ pub fn build_vault_index(vault_path: &Path) -> Result<JsonValue> {
     #[cfg(feature = "embed")]
     {
         use crate::config::vault_embedding_config;
-        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
+        use crate::embedding::{EmbeddingService, resolve_model};
         use crate::vector::VectorStore;
 
         let emb_cfg = vault_embedding_config(vault_path);
 
         if emb_cfg.enabled {
-            let model =
-                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
+            let model = resolve_model(&emb_cfg.model);
             embedding_model = model.as_str().to_string();
 
             let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-                model: model.as_str().to_string(),
+                model: emb_cfg.model.clone(),
                 auto_download: emb_cfg.auto_download,
                 cache_dir: emb_cfg.cache_dir.clone(),
                 enabled: true,

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -679,7 +679,7 @@ fn flush_embed_batch(
     pending: &mut Vec<(String, String, u64, String)>,
     service: &crate::embedding::EmbeddingService,
     store: &mut crate::vector::VectorStore,
-    model: &crate::embedding::EmbeddingModelChoice,
+    model: &crate::embedding::EmbeddingModel,
     counters: &mut VectorCounters,
 ) {
     if pending.is_empty() {
@@ -722,7 +722,7 @@ fn embed_files_in_batches(
     to_embed: &[ProjectFile],
     service: &crate::embedding::EmbeddingService,
     store: &mut crate::vector::VectorStore,
-    model: &crate::embedding::EmbeddingModelChoice,
+    model: &crate::embedding::EmbeddingModel,
     embed_batch: usize,
     vpb: &ProgressBar,
     counters: &mut VectorCounters,
@@ -760,7 +760,7 @@ fn run_full_vector_indexing(
     files_to_index: Vec<ProjectFile>,
 ) -> Result<(String, u64, u64, String)> {
     use crate::config::{effective_config, load_config};
-    use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
+    use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
     use crate::vector::VectorStore;
 
     let cfg = load_config();
@@ -769,7 +769,7 @@ fn run_full_vector_indexing(
         return Ok(("disabled".to_string(), 0, 0, String::new()));
     }
 
-    let model = EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+    let model = parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
     let service = EmbeddingService::new(crate::config::EmbeddingConfig {
         model: model.as_str().to_string(),
         auto_download: emb_cfg.auto_download,
@@ -1051,13 +1051,14 @@ pub fn build_vault_index(vault_path: &Path) -> Result<JsonValue> {
     #[cfg(feature = "embed")]
     {
         use crate::config::vault_embedding_config;
-        use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
+        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
         use crate::vector::VectorStore;
 
         let emb_cfg = vault_embedding_config(vault_path);
 
         if emb_cfg.enabled {
-            let model = EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+            let model =
+                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
             embedding_model = model.as_str().to_string();
 
             let service = EmbeddingService::new(crate::config::EmbeddingConfig {

--- a/src/index/searcher.rs
+++ b/src/index/searcher.rs
@@ -768,16 +768,14 @@ pub fn search_vault(vault_path: &Path, query: &str, limit: usize) -> Result<Json
     #[cfg(feature = "embed")]
     {
         use crate::config::vault_embedding_config;
-        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
+        use crate::embedding::EmbeddingService;
         use crate::vector::{VectorStore, reciprocal_rank_fusion};
 
         let emb_cfg = vault_embedding_config(vault_path);
 
         if emb_cfg.enabled {
-            let model =
-                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
             let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-                model: model.as_str().to_string(),
+                model: emb_cfg.model.clone(),
                 auto_download: emb_cfg.auto_download,
                 cache_dir: emb_cfg.cache_dir.clone(),
                 enabled: true,

--- a/src/index/searcher.rs
+++ b/src/index/searcher.rs
@@ -768,13 +768,14 @@ pub fn search_vault(vault_path: &Path, query: &str, limit: usize) -> Result<Json
     #[cfg(feature = "embed")]
     {
         use crate::config::vault_embedding_config;
-        use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
+        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
         use crate::vector::{VectorStore, reciprocal_rank_fusion};
 
         let emb_cfg = vault_embedding_config(vault_path);
 
         if emb_cfg.enabled {
-            let model = EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+            let model =
+                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
             let service = EmbeddingService::new(crate::config::EmbeddingConfig {
                 model: model.as_str().to_string(),
                 auto_download: emb_cfg.auto_download,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@ pub use vault::{
 #[cfg(feature = "embed")]
 pub use config::EmbeddingConfig;
 #[cfg(feature = "embed")]
-pub use embedding::{EmbeddingModel, EmbeddingService, ModelState, parse_legacy_model};
+pub use embedding::{
+    EmbeddingModel, EmbeddingService, ModelState, parse_legacy_model, resolve_model,
+};
 
 #[cfg(feature = "embed")]
 pub use index::search_hybrid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use vault::{
 #[cfg(feature = "embed")]
 pub use config::EmbeddingConfig;
 #[cfg(feature = "embed")]
-pub use embedding::{EmbeddingModelChoice, EmbeddingService, ModelState};
+pub use embedding::{EmbeddingModel, EmbeddingService, ModelState, parse_legacy_model};
 
 #[cfg(feature = "embed")]
 pub use index::search_hybrid;

--- a/src/server.rs
+++ b/src/server.rs
@@ -733,14 +733,12 @@ pub async fn run_server(
     #[cfg(feature = "embed")]
     let embedding_service = {
         use crate::config::load_config;
-        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
+        use crate::embedding::EmbeddingService;
 
         let cfg = load_config();
         let emb_cfg = cfg.embedding_config_with_defaults();
 
         if emb_cfg.enabled {
-            let model =
-                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
             let cache_dir = std::path::PathBuf::from(
                 emb_cfg
                     .cache_dir
@@ -752,7 +750,7 @@ pub async fn run_server(
             );
             Some(Arc::new(EmbeddingService::new(
                 crate::config::EmbeddingConfig {
-                    model: model.as_str().to_string(),
+                    model: emb_cfg.model.clone(),
                     auto_download: emb_cfg.auto_download,
                     cache_dir: cache_dir.to_string_lossy().into_owned(),
                     enabled: true,

--- a/src/server.rs
+++ b/src/server.rs
@@ -733,13 +733,14 @@ pub async fn run_server(
     #[cfg(feature = "embed")]
     let embedding_service = {
         use crate::config::load_config;
-        use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
+        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
 
         let cfg = load_config();
         let emb_cfg = cfg.embedding_config_with_defaults();
 
         if emb_cfg.enabled {
-            let model = EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+            let model =
+                parse_legacy_model(&emb_cfg.model).unwrap_or(EmbeddingModel::MultilingualE5Small);
             let cache_dir = std::path::PathBuf::from(
                 emb_cfg
                     .cache_dir

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1166,7 +1166,7 @@ fn step_summary(state: &mut SetupState) -> Result<StepResult> {
             if let Some(model_name) = model {
                 #[cfg(feature = "embed")]
                 {
-                    let m = crate::embedding::EmbeddingModelChoice::parse(model_name);
+                    let m = crate::embedding::parse_legacy_model(model_name);
                     println!(
                         "  Embedding: {} ({}d, ~{}MB)",
                         model_name,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -358,7 +358,7 @@ pub fn tool_search(
     #[cfg(feature = "embed")]
     {
         use crate::config::load_config;
-        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
+        use crate::embedding::EmbeddingService;
         use crate::index::search_hybrid;
 
         if crate::index::index_exists(docs_root) {
@@ -368,10 +368,8 @@ pub fn tool_search(
 
             // Create embedding service if enabled
             if emb_cfg.enabled {
-                let model = parse_legacy_model(&emb_cfg.model)
-                    .unwrap_or(EmbeddingModel::MultilingualE5Small);
                 let service = EmbeddingService::new(crate::config::EmbeddingConfig {
-                    model: model.as_str().to_string(),
+                    model: emb_cfg.model.clone(),
                     auto_download: emb_cfg.auto_download,
                     cache_dir: emb_cfg
                         .cache_dir

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -358,7 +358,7 @@ pub fn tool_search(
     #[cfg(feature = "embed")]
     {
         use crate::config::load_config;
-        use crate::embedding::{EmbeddingModelChoice, EmbeddingService};
+        use crate::embedding::{EmbeddingModel, EmbeddingService, parse_legacy_model};
         use crate::index::search_hybrid;
 
         if crate::index::index_exists(docs_root) {
@@ -368,7 +368,8 @@ pub fn tool_search(
 
             // Create embedding service if enabled
             if emb_cfg.enabled {
-                let model = EmbeddingModelChoice::parse(&emb_cfg.model).unwrap_or_default();
+                let model = parse_legacy_model(&emb_cfg.model)
+                    .unwrap_or(EmbeddingModel::MultilingualE5Small);
                 let service = EmbeddingService::new(crate::config::EmbeddingConfig {
                     model: model.as_str().to_string(),
                     auto_download: emb_cfg.auto_download,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -647,22 +647,13 @@ impl VectorStore {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-/// Compute cosine similarity between two vectors
+/// Compute cosine similarity between two vectors.
+///
+/// Delegates to `llm_kernel::embedding::cosine_similarity` which accumulates
+/// in f64 for better ranking stability with high-dimensional (384–1024) vectors.
 #[cfg(feature = "vector")]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() {
-        return 0.0;
-    }
-
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-
-    if mag_a < f32::EPSILON || mag_b < f32::EPSILON {
-        return 0.0;
-    }
-
-    dot / (mag_a * mag_b)
+    llm_kernel::embedding::cosine_similarity(a, b) as f32
 }
 
 /// Reciprocal Rank Fusion (RRF) for combining BM25 and vector search results


### PR DESCRIPTION
## Summary

Addresses code review feedback from #20 and fixes CI failure.

### Changes

| Issue | Fix |
|-------|-----|
| Double `parse_legacy_model` call in `EmbeddingService::new()` | Inline match, single parse |
| `model_code()` cache compatibility | Verified — all models produce identical HF cache folders |
| `test_model_id_uniqueness` removed | Investigated — llm-kernel shares `model_id`/`model_code` for same-repo Q variants by design (fastembed selects different ONNX files). No contract test needed. |
| DirectML CI failure (`ort` unresolved) | Re-add `ort` as optional dep for `embed-directml` feature |

### Verification

```
cargo clippy --features embed,vector    ✓ clean
cargo test --features embed,vector      ✓ 784 passed
cargo fmt --check                       ✓ clean
```