### PR TITLE
feat(config): add multi doc-root support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1287,6 +1287,7 @@ mod tests {
         assert!(roots[0].path.is_absolute());
         #[cfg(feature = "embed")]
         assert!(roots[0].embedding.is_none());
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1482,6 +1482,61 @@ mod tests {
     }
 
     #[test]
+    fn resolved_docs_roots_expands_tilde_in_docs_root() {
+        // Construct a path that starts with "~/" and verify it resolves to an
+        // absolute path (i.e. the tilde was expanded).
+        let home = dirs::home_dir().expect("home dir must exist for this test");
+        // Point at ~/.alcove itself — guaranteed to exist on any dev machine
+        // that has alcove installed, but safe to test even if it doesn't because
+        // we only check that the path is absolute, not that it's a dir.
+        let tilde_path = "~/.alcove".to_string();
+        let cfg = DocConfig {
+            docs_root: Some(tilde_path),
+            ..DocConfig::default()
+        };
+        let roots = cfg.resolved_docs_roots();
+        // If ~/.alcove exists as a dir we get one root; if not, zero. Either way
+        // verify the returned path (if any) does NOT contain a literal "~".
+        for r in &roots {
+            assert!(
+                r.path.is_absolute(),
+                "tilde must have been expanded: {:?}",
+                r.path
+            );
+            assert!(
+                !r.path.starts_with("~"),
+                "literal tilde must not appear in resolved path: {:?}",
+                r.path
+            );
+        }
+        // Sanity: the resolved path, when it exists, should start with home.
+        if !roots.is_empty() && roots[0].path.exists() {
+            assert!(roots[0].path.starts_with(&home));
+        }
+    }
+
+    #[test]
+    fn resolved_docs_roots_blocked_docs_root_skips_to_fallback() {
+        // Setting docs_root to a blocked path (e.g. /tmp which is blocked by
+        // is_blocked_system_path) should skip that entry and fall through to
+        // the default fallback, not panic.
+        let cfg = DocConfig {
+            docs_root: Some("/tmp".to_string()),
+            ..DocConfig::default()
+        };
+        // Should not panic; may return 0 or 1 roots depending on default dir.
+        let roots = cfg.resolved_docs_roots();
+        // /tmp must never appear in the results.
+        for r in &roots {
+            assert_ne!(
+                r.path.to_string_lossy().as_ref(),
+                "/tmp",
+                "blocked path must not appear in resolved roots"
+            );
+        }
+    }
+
+    #[test]
     fn classify_reports_backslash() {
         assert_eq!(classify_tier("reports\\weekly.md"), "reference");
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1287,7 +1287,6 @@ mod tests {
         assert!(roots[0].path.is_absolute());
         #[cfg(feature = "embed")]
         assert!(roots[0].embedding.is_none());
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]
@@ -1342,6 +1341,30 @@ mod tests {
         assert_eq!(roots2.len(), 2);
         assert_eq!(roots2[0].name, "oss");
         assert_eq!(roots2[1].name, "work");
+    }
+
+    #[test]
+    fn resolved_docs_roots_legacy_takes_precedence_over_vec() {
+        let base = alcove_home().join(format!("test-legacy-root-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        let _guard = TempDir(base.clone());
+        let cfg = DocConfig {
+            docs_root: Some(base.to_string_lossy().to_string()),
+            docs_roots: Some(vec![DocRootEntry {
+                name: "oss".into(),
+                path: alcove_home()
+                    .join("test-oss-root")
+                    .to_string_lossy()
+                    .to_string(),
+                #[cfg(feature = "embed")]
+                embedding: None,
+            }]),
+            ..DocConfig::default()
+        };
+        // legacy docs_root takes precedence
+        let roots = cfg.resolved_docs_roots();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].path, base.canonicalize().unwrap_or(base.clone()));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1062,10 +1062,18 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
     // For multi-root: find the root whose CWD match resolves the project.
     // When detected via CWD, verify the CWD is actually under that root to
     // prevent selecting the wrong root when multiple roots share a project name.
+    // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
+    // multiple roots (ambiguity).
     let (docs_root, resolved) = {
         let mut found = None;
+        let mut ambiguous_env = false;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
+                if found.is_some() && r.detected_via == "env" {
+                    // Same project name resolved in another root — ambiguity.
+                    ambiguous_env = true;
+                    break;
+                }
                 if r.detected_via == "cwd" {
                     // Cross-validate: CWD must be under this root's path
                     if let Ok(cwd) = std::env::current_dir()
@@ -1076,9 +1084,19 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                         continue; // Name matched but CWD is under a different root
                     }
                 }
+                let is_cwd = r.detected_via == "cwd";
                 found = Some((root.path.clone(), r));
-                break;
+                // For CWD detection, stop at first validated match.
+                // For env detection, continue scanning to detect ambiguity.
+                if is_cwd {
+                    break;
+                }
             }
+        }
+        if ambiguous_env {
+            eprintln!(
+                "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — using the first match. Consider running from the project directory instead."
+            );
         }
         match found {
             Some(pair) => pair,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1070,15 +1070,10 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
     // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
     // multiple roots (ambiguity).
     let (docs_root, resolved) = {
-        let mut found = None;
+        let mut found: Option<(std::path::PathBuf, _)> = None;
         let mut ambiguous_env = false;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
-                if found.is_some() && r.detected_via == "env" {
-                    // Same project name resolved in another root — ambiguity.
-                    ambiguous_env = true;
-                    break;
-                }
                 if r.detected_via == "cwd" {
                     // Cross-validate: CWD must be under this root's path
                     if let Ok(cwd) = std::env::current_dir()
@@ -1088,13 +1083,16 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     {
                         continue; // Name matched but CWD is under a different root
                     }
-                }
-                let is_cwd = r.detected_via == "cwd";
-                found = Some((root.path.clone(), r));
-                // For CWD detection, stop at first validated match.
-                // For env detection, continue scanning to detect ambiguity.
-                if is_cwd {
-                    break;
+                    found = Some((root.path.clone(), r));
+                    break; // CWD detection is unambiguous — stop at first validated match
+                } else {
+                    // env detection: record first match, flag if a second match appears
+                    if found.is_some() {
+                        ambiguous_env = true;
+                        break;
+                    }
+                    found = Some((root.path.clone(), r));
+                    // continue scanning remaining roots to detect ambiguity
                 }
             }
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1030,18 +1030,23 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     return ok!(v);
                 }
             }
-            // Grep fallback: return results from the first root that has matches.
-            // Full cross-root grep merge is not implemented — use indexed search
-            // for comprehensive multi-root results.
+            // Grep fallback: merge results from all roots for comprehensive coverage.
+            let mut merged_matches: Vec<Value> = Vec::new();
+            let mut truncated = false;
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
-                    if has_matches {
-                        return ok!(v);
+                    if let Some(arr) = v["matches"].as_array() {
+                        merged_matches.extend(arr.clone());
                     }
+                    truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
                 }
             }
-            return ok!(json!({"query": query, "matches": [], "truncated": false, "mode": "grep"}));
+            return ok!(json!({
+                "query": query,
+                "matches": merged_matches,
+                "truncated": truncated,
+                "mode": "grep",
+            }));
         }
 
         if !force_grep {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1021,8 +1021,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
         if is_global {
             // Multi-root global search: try indexed search across all roots in parallel,
             // fall back to grep-based global search on the primary root.
-            if !force_grep && let Ok(v) =
-                tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
+            if !force_grep
+                && let Ok(v) =
+                    tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
             {
                 let matches = v["matches"].as_array();
                 if matches.is_some_and(|m| !m.is_empty()) {
@@ -1032,9 +1033,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             // Grep fallback: try each root until we get results.
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    let has_matches = v["matches"]
-                        .as_array()
-                        .is_some_and(|m| !m.is_empty());
+                    let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
                     if has_matches {
                         return ok!(v);
                     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1030,7 +1030,9 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     return ok!(v);
                 }
             }
-            // Grep fallback: try each root until we get results.
+            // Grep fallback: return results from the first root that has matches.
+            // Full cross-root grep merge is not implemented — use indexed search
+            // for comprehensive multi-root results.
             for root in &all_roots {
                 if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
                     let has_matches = v["matches"].as_array().is_some_and(|m| !m.is_empty());
@@ -1058,10 +1060,22 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
 
     // All other tools require a resolved project.
     // For multi-root: find the root whose CWD match resolves the project.
+    // When detected via CWD, verify the CWD is actually under that root to
+    // prevent selecting the wrong root when multiple roots share a project name.
     let (docs_root, resolved) = {
         let mut found = None;
         for root in &all_roots {
             if let Some(r) = tools::resolve_project(&root.path) {
+                if r.detected_via == "cwd" {
+                    // Cross-validate: CWD must be under this root's path
+                    if let Ok(cwd) = std::env::current_dir()
+                        && let Ok(canonical_root) = root.path.canonicalize()
+                        && let Ok(canonical_cwd) = cwd.canonicalize()
+                        && !canonical_cwd.starts_with(&canonical_root)
+                    {
+                        continue; // Name matched but CWD is under a different root
+                    }
+                }
                 found = Some((root.path.clone(), r));
                 break;
             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1041,7 +1041,7 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
                     }
                 }
             }
-            return ok!(json!({"query": "", "matches": [], "truncated": false, "mode": "grep"}));
+            return ok!(json!({"query": query, "matches": [], "truncated": false, "mode": "grep"}));
         }
 
         if !force_grep {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1018,6 +1018,31 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             .unwrap_or("");
         let force_grep = mode_override == Some("grep");
 
+        if is_global {
+            // Multi-root global search: try indexed search across all roots in parallel,
+            // fall back to grep-based global search on the primary root.
+            if !force_grep && let Ok(v) =
+                tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
+            {
+                let matches = v["matches"].as_array();
+                if matches.is_some_and(|m| !m.is_empty()) {
+                    return ok!(v);
+                }
+            }
+            // Grep fallback: try each root until we get results.
+            for root in &all_roots {
+                if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
+                    let has_matches = v["matches"]
+                        .as_array()
+                        .is_some_and(|m| !m.is_empty());
+                    if has_matches {
+                        return ok!(v);
+                    }
+                }
+            }
+            return ok!(json!({"query": "", "matches": [], "truncated": false, "mode": "grep"}));
+        }
+
         if !force_grep {
             let index_dir = docs_root.join(".alcove").join("index");
             if (index_dir.exists() || crate::index::ensure_index_fresh(&docs_root))
@@ -1031,6 +1056,53 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             }
         }
     }
+
+    // All other tools require a resolved project.
+    // For multi-root: find the root whose CWD match resolves the project.
+    let (docs_root, resolved) = {
+        let mut found = None;
+        for root in &all_roots {
+            if let Some(r) = tools::resolve_project(&root.path) {
+                found = Some((root.path.clone(), r));
+                break;
+            }
+        }
+        match found {
+            Some(pair) => pair,
+            None => {
+                let available: Vec<String> = all_roots
+                    .iter()
+                    .flat_map(|root| {
+                        std::fs::read_dir(&root.path)
+                            .ok()
+                            .map(|rd| {
+                                rd.filter_map(std::result::Result::ok)
+                                    .filter(|e| e.path().is_dir())
+                                    .filter_map(|e| {
+                                        let name = e.file_name().to_string_lossy().to_string();
+                                        if is_reserved_dir_name(&name) {
+                                            None
+                                        } else {
+                                            Some(name)
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect();
+                return err!(
+                    -32001,
+                    format!(
+                        "Could not detect project. CWD does not match any project in DOCS_ROOT. \
+                         Available projects: [{}]. \
+                         Set MCP_PROJECT_NAME env var or run from within a project directory.",
+                        available.join(", ")
+                    )
+                );
+            }
+        }
+    };
 
     let project_root = docs_root.join(&resolved.name);
     let repo_path = resolved.repo_path.as_deref();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1018,37 +1018,6 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             .unwrap_or("");
         let force_grep = mode_override == Some("grep");
 
-        if is_global {
-            // Multi-root global search: try indexed search across all roots in parallel,
-            // fall back to grep-based global search on the primary root.
-            if !force_grep
-                && let Ok(v) =
-                    tools::tool_search_global_multi(&all_roots, call.arguments.clone(), limit)
-            {
-                let matches = v["matches"].as_array();
-                if matches.is_some_and(|m| !m.is_empty()) {
-                    return ok!(v);
-                }
-            }
-            // Grep fallback: merge results from all roots for comprehensive coverage.
-            let mut merged_matches: Vec<Value> = Vec::new();
-            let mut truncated = false;
-            for root in &all_roots {
-                if let Ok(v) = tools::tool_search_global(&root.path, call.arguments.clone()) {
-                    if let Some(arr) = v["matches"].as_array() {
-                        merged_matches.extend(arr.clone());
-                    }
-                    truncated = truncated || v["truncated"].as_bool().unwrap_or(false);
-                }
-            }
-            return ok!(json!({
-                "query": query,
-                "matches": merged_matches,
-                "truncated": truncated,
-                "mode": "grep",
-            }));
-        }
-
         if !force_grep {
             let index_dir = docs_root.join(".alcove").join("index");
             if (index_dir.exists() || crate::index::ensure_index_fresh(&docs_root))
@@ -1062,81 +1031,6 @@ fn handle_tool_call(id: Option<Value>, params: Value) -> RpcResponse {
             }
         }
     }
-
-    // All other tools require a resolved project.
-    // For multi-root: find the root whose CWD match resolves the project.
-    // When detected via CWD, verify the CWD is actually under that root to
-    // prevent selecting the wrong root when multiple roots share a project name.
-    // When detected via MCP_PROJECT_NAME env var, warn if the name exists in
-    // multiple roots (ambiguity).
-    let (docs_root, resolved) = {
-        let mut found: Option<(std::path::PathBuf, _)> = None;
-        let mut ambiguous_env = false;
-        for root in &all_roots {
-            if let Some(r) = tools::resolve_project(&root.path) {
-                if r.detected_via == "cwd" {
-                    // Cross-validate: CWD must be under this root's path
-                    if let Ok(cwd) = std::env::current_dir()
-                        && let Ok(canonical_root) = root.path.canonicalize()
-                        && let Ok(canonical_cwd) = cwd.canonicalize()
-                        && !canonical_cwd.starts_with(&canonical_root)
-                    {
-                        continue; // Name matched but CWD is under a different root
-                    }
-                    found = Some((root.path.clone(), r));
-                    break; // CWD detection is unambiguous — stop at first validated match
-                } else {
-                    // env detection: record first match, flag if a second match appears
-                    if found.is_some() {
-                        ambiguous_env = true;
-                        break;
-                    }
-                    found = Some((root.path.clone(), r));
-                    // continue scanning remaining roots to detect ambiguity
-                }
-            }
-        }
-        if ambiguous_env {
-            eprintln!(
-                "[alcove] WARNING: MCP_PROJECT_NAME matches projects in multiple roots — using the first match. Consider running from the project directory instead."
-            );
-        }
-        match found {
-            Some(pair) => pair,
-            None => {
-                let available: Vec<String> = all_roots
-                    .iter()
-                    .flat_map(|root| {
-                        std::fs::read_dir(&root.path)
-                            .ok()
-                            .map(|rd| {
-                                rd.filter_map(std::result::Result::ok)
-                                    .filter(|e| e.path().is_dir())
-                                    .filter_map(|e| {
-                                        let name = e.file_name().to_string_lossy().to_string();
-                                        if is_reserved_dir_name(&name) {
-                                            None
-                                        } else {
-                                            Some(name)
-                                        }
-                                    })
-                                    .collect::<Vec<_>>()
-                            })
-                            .unwrap_or_default()
-                    })
-                    .collect();
-                return err!(
-                    -32001,
-                    format!(
-                        "Could not detect project. CWD does not match any project in DOCS_ROOT. \
-                         Available projects: [{}]. \
-                         Set MCP_PROJECT_NAME env var or run from within a project directory.",
-                        available.join(", ")
-                    )
-                );
-            }
-        }
-    };
 
     let project_root = docs_root.join(&resolved.name);
     let repo_path = resolved.repo_path.as_deref();


### PR DESCRIPTION
## Summary
`docs_roots` 배열을 통해 다중 doc-root를 지원합니다. 기존 `docs_root` 단일 필드는 후방 호환으로 유지됩니다.

## Changes
- `src/config.rs`: `DocRootEntry`, `ResolvedDocRoot`, `resolved_docs_roots()` 추가
- `src/mcp.rs`: `resolve_project_multi()`, `ok_with_root!` 매크로로 다중 루트 처리
- `src/tools.rs`: `list_projects_impl`, `tool_search_global_multi` 다중 루트 지원

## Config Example
```toml
[[docs_roots]]
name = "oss"
path = "~/.alcove/docs-oss"

[[docs_roots]]
name = "work"
path = "~/.alcove/docs-work"
```

## Notes
- `DOCS_ROOT` 환경변수 > `docs_root` > `docs_roots` 우선순위 유지
- main 위로 rebase 완료 (feat/path 충돌 해결 포함)