### PR TITLE
chore(deps): migrate llm-kernel 0.3.5 → 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,11 +2435,12 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-kernel"
-version = "0.3.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df114f3a9196995b278e7ce90fc124e2bad74ee6236c04f1602d33a44b1cfd32"
+checksum = "1d99ed60127e6d444acd79033d00018b951480a1c086927bb61e84441a3b85af"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fastembed",
  "indexmap",
  "ort",
@@ -5048,9 +5049,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "turbovec"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499c587338ef613f0a19e633f6aa63fe42d7003c44886889b934841846c4d552"
+checksum = "0715a5a1365e86d0ae6396fa0c011f319b8e8024b3896cd16e6468e29ed3a325"
 dependencies = [
  "faer",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 # Embedding backend — delegates to llm-kernel for model catalog, metadata,
 # and LRU cache. fastembed remains a direct dep for FastEmbedSession
 # (prefix control). llm-kernel uses the same rustls-based defaults.
-llm-kernel = { version = "0.3.5", default-features = false }
+llm-kernel = { version = "0.9.2", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing


### PR DESCRIPTION
## Summary
alcove의 llm-kernel 의존성을 0.3.5에서 0.9.2로 업그레이드합니다. embedding API가 완전 호환되어 소스 코드 수정 없이 버전 범프만으로 완료되었습니다.

## Spec
- ID: SPEC-20260622092216
- Pipeline: PIPELINE-20260622092113
- Requirements: R1 (버전 범프), R2 (API 호환성), R3 (테스트 통과)

## Changes
- `Cargo.toml`: llm-kernel 0.3.5 → 0.9.2
- `Cargo.lock`: llm-kernel 0.9.2 + turbovec 0.9.0 (transitive)

## Acceptance Criteria Verified
- AC1: ✅ Cargo.toml llm-kernel = "0.9.2"
- AC2: ✅ `cargo build --features full-macos` 오류/경고 없음
- AC3: ✅ 566/566 tests pass

## Check Report
## Check Report
- Spec: SPEC-20260622092216 (migrate-llm-kernel-0-9-2)
- Branch: worktree-orbit-migrate-llm-kernel-0-9-2
- Scopes: [Dependencies]

### Code Quality: PASS
- 변경 파일: Cargo.toml, Cargo.lock (소스 코드 변경 없음)
- clippy 경고/오류: 없음
- llm-kernel 0.9.2 embedding API 완전 호환 확인 (TurbovecIndex, EmbeddingCache, cosine_similarity, EmbeddingModel, is_model_cached, DirectMLExecutionProvider 모두 동일 경로 유지)
- turbovec 0.8.0 → 0.9.0 자동 업데이트 (transitive dep)

### Security: PASS
- 의존성 버전 범프만. 외부 API 노출 변경 없음.

### Tests: PASS
- cargo test --features full-macos: 566 passed; 0 failed; finished in 8.62s
- bench tests: 4 passed; 1 ignored

### Requirements Coverage
- R1: ✅ llm-kernel = "0.9.2" in Cargo.toml
- R2: ✅ API 완전 호환, 소스 수정 불필요
- R3: ✅ 566 tests pass

### Acceptance Criteria
- AC1: ✅ Cargo.toml llm-kernel = "0.9.2"
- AC2: ✅ cargo build --features full-macos Finished in 10.20s (no errors)
- AC3: ✅ 566/566 tests pass

### Action Items
없음 — 모든 검사 통과

## Test Plan
- [x] Unit tests pass (566/566)
- [x] Integration tests pass
- [x] Manual verification: clippy 경고 없음

Closes #35