### PR TITLE
chore(deps): upgrade llm-kernel 0.9.2 -> 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,16 +2380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,11 +2425,10 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-kernel"
-version = "0.9.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99ed60127e6d444acd79033d00018b951480a1c086927bb61e84441a3b85af"
+checksum = "51b88aaa6025e3d0034301c61447e4cd6e957f72582adaf8bec194a1d1c8fdef"
 dependencies = [
- "anyhow",
  "async-trait",
  "fastembed",
  "indexmap",
@@ -3074,7 +3063,6 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 # Embedding backend — delegates to llm-kernel for model catalog, metadata,
 # and LRU cache. fastembed remains a direct dep for FastEmbedSession
 # (prefix control). llm-kernel uses the same rustls-based defaults.
-llm-kernel = { version = "0.9.2", default-features = false }
+llm-kernel = { version = "0.14", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing


### PR DESCRIPTION
## Summary

Upgrades `llm-kernel` from **0.9.2 → 0.14.0** (latest). Issue #38 tracked the 0.10.0 bump; five additional minors (0.10–0.14) have shipped since, so this jumps straight to current.

## Breaking-change impact: **none** (no source changes)

llm-kernel 0.10–0.14 breaking changes were audited against alcove's actual API surface (`TurbovecIndex`, `VectorIndex`/`SearchHit`, `cosine_similarity`, `EmbeddingCache`, `EmbeddingModel`, `is_model_cached`, `ort`). Every breaking change is no-op for alcove:

| Version | Breaking change | alcove impact |
|---------|-----------------|---------------|
| 0.10.0 | `smart_recall` graph boost → PageRank | **None** — alcove does not route recall/search through llm-kernel's `smart_recall`/graph |
| 0.11.0 | `PgGraph` TLS | **None** — `graph-pg` unused |
| 0.12.0 | `ModelState::Failed(String)` → `{ message, panicked }` | **None** — alcove's `ModelState` (`src/embedding.rs`) is **locally defined**, not re-exported |
| 0.12.0 | ort static linking default (glibc 2.38+) | **None** — alcove already uses the identical static `ort-download-binaries-rustls-tls` fastembed config |
| 0.13.0 | embedding/vector `anyhow::Result` → `KernelError` | **Compatible** — `TurbovecIndex::new(...)?` call sites are inside `anyhow::Result` functions; `KernelError: std::error::Error + Send + Sync` so `From` is auto-provided and `?` absorbs it |
| 0.13.0 | `KernelError::Embedding`/`Discovery` variants | **None** — alcove never matches `KernelError` |
| 0.14.0 | `KernelError` `#[non_exhaustive]` | **None** — never matched |
| 0.14.0 | catalog/graph/mcp types `non_exhaustive` | **None** — modules unused |
| 0.14.0 | `OpenAIClient`/`AnthropicClient::from_key` → `Result` | **None** — alcove does not use llm-kernel LLM clients |

The `fastembed` dependency config is **byte-identical** between alcove and llm-kernel 0.14 (`fastembed 5`, `hf-hub-rustls-tls` + `ort-download-binaries-rustls-tls`), so there is no Cargo feature-unification conflict. This also drops `ort-load-dynamic` → `libloading` (removed in llm-kernel 0.12.0).

## Verification

```
cargo check                          ✓
cargo check --features full-macos    ✓
cargo build --features full-macos    ✓  (no clang_rt.osx / ort link warnings on macOS)
cargo clippy --features full-macos -- -D warnings   ✓
cargo fmt --check                    ✓
cargo test --features full-macos -- --test-threads=1 --include-ignored
  → 566 + 5 passed, 0 failed
```

Vector tests (`cosine_similarity`, `remove_by_ids`, `search_filtered`, `rrf`) all green → TurbovecIndex 0.14 compatibility confirmed. Recall quality unaffected since alcove does not use `smart_recall`.

Closes #38
