### PR TITLE
fix(ci): pin macOS runner to macos-14 (clang_rt.osx linker flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,14 @@ jobs:
 
   test:
     name: Test
-    # Pinned to macos-14: the rolling `macos-latest` image intermittently ships
-    # a broken compiler-rt path (linker error: "ld: library 'clang_rt.osx' not
-    # found"), which breaks the ort/fastembed static link on an otherwise-green
-    # commit. macos-14 has a stable Xcode/clang toolchain. Revisit once ort's
-    # prebuilt static archive tracks the newer clang runtime path.
+    # Pinned to macos-14 to dodge rolling-image compiler-rt regressions, AND
+    # works around a clang_rt link failure present on the Xcode 16.4 image
+    # (both macos-latest and macos-14): ort-sys emits `-lclang_rt.osx` plus a
+    # `-L .../clang/17/lib/darwin` search path that does not exist on this
+    # toolchain, so `ld: library 'clang_rt.osx' not found` aborts the link of
+    # the full-macos test binary. The step below locates the real
+    # libclang_rt.osx.a and exposes its directory as a link path. Revisit once
+    # ort's prebuilt static archive tracks the newer clang runtime path.
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -97,8 +100,20 @@ jobs:
           # Persist fastembed/ort ONNX Runtime downloads so a transient
           # re-fetch doesn't break native linking on cache misses.
           cache-directories: ~/Library/Caches/ort.pyke.io
+      - name: Locate clang_rt.osx (Xcode 16.4 link-path workaround)
+        run: |
+          set -e
+          RT="$(find /Applications/Xcode*.app -name 'libclang_rt.osx.a' -print -quit 2>/dev/null)"
+          if [ -z "$RT" ]; then
+            echo "::error::libclang_rt.osx.a not found under /Applications/Xcode*.app"
+            exit 1
+          fi
+          echo "Found clang_rt at: $RT"
+          echo "CLANG_RT_DIR=$(dirname "$RT")" >> "$GITHUB_ENV"
       - name: Test
         run: cargo test --locked --features full-macos -- --test-threads=1
+        env:
+          RUSTFLAGS: "-L${{ env.CLANG_RT_DIR }}"
 
   test-linux:
     name: Test (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,12 @@ jobs:
 
   test:
     name: Test
-    runs-on: macos-latest
+    # Pinned to macos-14: the rolling `macos-latest` image intermittently ships
+    # a broken compiler-rt path (linker error: "ld: library 'clang_rt.osx' not
+    # found"), which breaks the ort/fastembed static link on an otherwise-green
+    # commit. macos-14 has a stable Xcode/clang toolchain. Revisit once ort's
+    # prebuilt static archive tracks the newer clang runtime path.
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,3 +27,12 @@ macos-sign = false
 
 [dist.dependencies.apt]
 libopenblas-dev = "*"
+
+# Pin the native Apple Silicon build to macos-14. The rolling macos-latest
+# image intermittently ships a broken compiler-rt path, breaking the
+# ort/fastembed static link ("ld: library 'clang_rt.osx' not found") for the
+# full-macos aarch64-apple-darwin artifact. macos-14 has a stable Xcode/clang
+# toolchain. Revisit once ort's prebuilt static archive tracks the newer clang
+# runtime path.
+[dist.github-custom-runners]
+aarch64-apple-darwin = "macos-14"


### PR DESCRIPTION
## Problem

The macOS Test job went red on 2026-07-03 with:

```
ld: warning: search path '.../clang/17/lib/darwin' not found
ld: library 'clang_rt.osx' not found
error: linking with `cc` failed
```

This is the ort/fastembed static link failing because the rolling `macos-latest` image intermittently ships a broken compiler-rt path. Same job was green on 2026-06-26 under the same `macos-latest` label — the underlying image revision regressed.

## Scope

**Independent of llm-kernel 0.14 and PR #41.** It reproduces on pre-bump main (llm-kernel 0.9.2) and is a **release blocker**: dist builds the `aarch64-apple-darwin`/`full-macos` artifact on a macOS runner, so the same link step fails there too.

## Fix

Pin macOS to `macos-14` (stable Xcode/clang toolchain) in both CI and the dist release build. Mirrors the fix applied in [samvallad33/vestige](https://github.com/samvallad33/vestige) for the identical issue.

- `.github/workflows/ci.yml`: Test job `macos-latest` → `macos-14`
- `dist-workspace.toml`: `[dist.github-custom-runners] aarch64-apple-darwin = "macos-14"` (dist's plan reads this, so the release.yml matrix picks it up automatically — no hand-edit of the generated `release.yml`)

`release.yml` itself is untouched; dist regenerates it on the next `dist generate`. Revisit once ort's prebuilt static archive tracks the newer clang runtime path.

## After this lands

PR #41 (RUSTSEC audit fix) re-evaluates on macos-14 and should go fully green, unblocking the 0.12.3 release.
