### PR TITLE
chore(release): bump version 0.12.2 → 0.12.3

### DIFF
--- a/.github/dist/build-setup.yml
+++ b/.github/dist/build-setup.yml
@@ -1,0 +1,28 @@
+# Injected by cargo-dist into the build-local-artifacts job before `dist build`
+# (see dist-workspace.toml -> [dist].github-build-setup).
+#
+# Works around the Xcode 16.4 clang_rt link-path regression: ort-sys emits
+# `-lclang_rt.osx` with a `-L .../clang/17/lib/darwin` search path that does
+# not exist on this toolchain, so `ld: library 'clang_rt.osx' not found`
+# aborts the macOS static ort/fastembed link for the aarch64-apple-darwin /
+# full-macos artifact. We locate the real libclang_rt.osx.a and expose its
+# directory to the link step via RUSTFLAGS. Only the native Apple Silicon
+# build is affected. Revisit once ort's prebuilt static archive tracks the
+# newer clang runtime path.
+- name: Locate clang_rt.osx (macOS aarch64 only)
+  if: ${{ env.CARGO_DIST_TARGET == 'aarch64-apple-darwin' }}
+  shell: bash
+  run: |
+    set -e
+    RT="$(find /Applications/Xcode*.app -name 'libclang_rt.osx.a' -print -quit 2>/dev/null)"
+    if [ -z "$RT" ]; then
+      echo "::error::libclang_rt.osx.a not found under /Applications/Xcode*.app"
+      exit 1
+    fi
+    echo "Found clang_rt at: $RT"
+    echo "CLANG_RT_DIR=$(dirname "$RT")" >> "$GITHUB_ENV"
+- name: Export RUSTFLAGS for macOS link
+  if: ${{ env.CARGO_DIST_TARGET == 'aarch64-apple-darwin' }}
+  shell: bash
+  run: |
+    echo "RUSTFLAGS=-L${CLANG_RT_DIR}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,23 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Locate clang_rt.osx (macOS aarch64 only)"
+        if: "${{ env.CARGO_DIST_TARGET == 'aarch64-apple-darwin' }}"
+        run: |
+          set -e
+          RT="$(find /Applications/Xcode*.app -name 'libclang_rt.osx.a' -print -quit 2>/dev/null)"
+          if [ -z "$RT" ]; then
+            echo "::error::libclang_rt.osx.a not found under /Applications/Xcode*.app"
+            exit 1
+          fi
+          echo "Found clang_rt at: $RT"
+          echo "CLANG_RT_DIR=$(dirname "$RT")" >> "$GITHUB_ENV"
+        shell: "bash"
+      - name: "Export RUSTFLAGS for macOS link"
+        if: "${{ env.CARGO_DIST_TARGET == 'aarch64-apple-darwin' }}"
+        run: |
+          echo "RUSTFLAGS=-L${CLANG_RT_DIR}" >> "$GITHUB_ENV"
+        shell: "bash"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] — 2026-07-03
+
+### Changed
+
+- Upgraded llm-kernel from 0.9.2 to 0.14 (forward-compatible — no source changes; alcove's API surface was unaffected by the 0.10–0.14 breaking changes)
+
+### Security
+
+- Cleared RUSTSEC-2026-0187 (lopdf), RUSTSEC-2026-0193 (ammonia), and RUSTSEC-2026-0194/0195 (quick-xml) by bumping pdf-extract 0.10 → 0.12, llm-transpile 0.3 → 0.4, and the direct quick-xml dep 0.40 → 0.41; the residual quick-xml 0.39 advisory (via calamine, whose latest release still pins `^0.39`) is documented-ignored in `.cargo/audit.toml`
+
+### Fixed
+
+- Pinned macOS CI and release runners to macos-14 and injected the `clang_rt.osx` link path, working around the Xcode 16.4 compiler-rt regression that broke the ort/fastembed static link for the `aarch64-apple-darwin`/`full-macos` build
+
 ## [0.12.1] — 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "alcove"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alcove"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "A quiet place for your project docs. MCP server that gives AI agents scoped access to private documentation."
 license = "Apache-2.0"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,6 +24,10 @@ install-updater = false
 publish-jobs = ["homebrew", "./publish-crates"]
 allow-dirty = ["ci"]
 macos-sign = false
+# Inject clang_rt.osx link-path setup before `dist build` so the macOS
+# aarch64-apple-darwin artifact links under the Xcode 16.4 image. See
+# .github/dist/build-setup.yml.
+github-build-setup = "../dist/build-setup.yml"
 
 [dist.dependencies.apt]
 libopenblas-dev = "*"


### PR DESCRIPTION
Release prep for **0.12.3**, shipping the three main-branch fixes from this session plus the dist infrastructure that lets the macOS release artifact build.

## What's in the release

| Change | PR | Type |
|--------|----|------|
| llm-kernel 0.9.2 → 0.14 | #40 | dep upgrade |
| RUSTSEC-2026-0187/0193/0194/0195 cleared; residual calamine quick-xml 0.39 ignored | #41 | security |
| macOS runner pinned to macos-14 + clang_rt.osx link path | #42 | ci fix |

## This PR adds

- `Cargo.toml` / `Cargo.lock`: `0.12.2` → `0.12.3`
- `CHANGELOG.md`: `[0.12.3] — 2026-07-03` (Changed / Security / Fixed)
- **dist clang_rt workaround**: `.github/dist/build-setup.yml` + `dist-workspace.toml` `[dist].github-build-setup` → `release.yml` regenerated so the `aarch64-apple-darwin`/`full-macos` release artifact gets the same clang_rt link path that fixed CI in #42. The release build would otherwise hit the identical `ld: library 'clang_rt.osx' not found`.

## After merge

`v0.12.3` tag push → `release.yml` runs → builds all 4 targets (incl. macOS) and publishes to crates.io + homebrew tap. Tag/push is the irreversible outward step, so it's held for explicit go-ahead.
