### PR TITLE
fix(deps): roll back llm-kernel 0.14 -> 0.9.2 (release 0.12.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4] — 2026-07-04
+
+### Changed
+
+- Rolled back llm-kernel 0.14 → 0.9.2: llm-kernel 0.12.0 removed `ort-load-dynamic` in favor of a statically-linked ONNX Runtime, which broke the Linux and Windows `dist` release builds (the static archive references glibc 2.38+ symbols like `__isoc23_strtoll` and 50 unresolved MSVC CRT externals). 0.9.2 uses dynamic ort linking, restoring release compatibility. The RUSTSEC advisory cleanup, the macOS `clang_rt` link fix, and the `cargo audit` green state are all retained (independent of llm-kernel).
+
 ## [0.12.3] — 2026-07-03
+
+> Not published — the tag's release run built macOS only; Linux and Windows artifacts failed to link (see 0.12.4).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "alcove"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2359,6 +2359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,10 +2414,11 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-kernel"
-version = "0.14.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b88aaa6025e3d0034301c61447e4cd6e957f72582adaf8bec194a1d1c8fdef"
+checksum = "1d99ed60127e6d444acd79033d00018b951480a1c086927bb61e84441a3b85af"
 dependencies = [
+ "anyhow",
  "async-trait",
  "fastembed",
  "indexmap",
@@ -3013,6 +3024,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alcove"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 description = "A quiet place for your project docs. MCP server that gives AI agents scoped access to private documentation."
 license = "Apache-2.0"
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 # Embedding backend — delegates to llm-kernel for model catalog, metadata,
 # and LRU cache. fastembed remains a direct dep for FastEmbedSession
 # (prefix control). llm-kernel uses the same rustls-based defaults.
-llm-kernel = { version = "0.14", default-features = false }
+llm-kernel = { version = "0.9.2", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing


### PR DESCRIPTION
Rolls back llm-kernel to 0.9.2 to restore Linux/Windows release builds — 0.14's static ort link failed (Linux glibc 2.38 / MSVC CRT). audit + clang_rt fixes retained. Bumps alcove to 0.12.4 for a fresh release tag (0.12.3 was attempted but never published).