### PR TITLE
chore(deps): upgrade llm-kernel 0.9.2 -> 0.15 + release-link CI gate (0.12.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,30 @@ jobs:
         with:
           name: sbom
           path: "*.cdx.json"
+
+  # Release-link gate: `cargo check` does not link, so a static-link
+  # regression (e.g. ort's static archive requiring glibc 2.38+ / MSVC CRT
+  # symbols) only surfaces at `cargo build --release`. Run that here on the
+  # exact runner images the dist release uses, so a link failure fails the PR
+  # instead of the tagged release run.
+  release-build-linux:
+    name: Release build (Linux, static ort link)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install OpenBLAS (required by TurboQuant/turbovec)
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+      - name: Release build
+        run: cargo build --release --locked --features full-cross
+
+  release-build-windows:
+    name: Release build (Windows, static ort link)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Release build
+        run: cargo build --release --locked --features full-cross

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] — 2026-07-06
+
+### Changed
+
+- Upgraded llm-kernel 0.9.2 → 0.15.0. Restores the upgrade path that 0.12.4 rolled back: llm-kernel 0.15.0 hardened the dynamic-linking escape hatch (mutually-exclusive `embedding-fastembed` / `embedding-fastembed-dynamic-linking`) and added a release-link CI gate, so the static ort link is now safe to consume upstream-side (llm-kernel [#55]).
+
+### Fixed
+
+- dist Linux artifacts now build on `ubuntu-24.04` (glibc 2.39) to satisfy the static ort archive's glibc ≥2.38 link requirement. Trade-off: produced Linux binaries require glibc ≥2.38 at runtime (ubuntu-24.04+ / recent distros).
+- CI gained `Release build (Linux/Windows)` jobs running `cargo build --release --locked --features full-cross`, so a static-link regression is caught on the PR (not at tagged-release time — the gap that let 0.12.3 ship a broken release).
+
+[llm-kernel #55]: https://github.com/epicsagas/llm-kernel/issues/55
+
 ## [0.12.4] — 2026-07-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "alcove"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2359,16 +2359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,11 +2404,10 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-kernel"
-version = "0.9.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99ed60127e6d444acd79033d00018b951480a1c086927bb61e84441a3b85af"
+checksum = "22fb82f7da7e6a1271813248e19eb194e5d186f8fbff157ad63078a71f2c9703"
 dependencies = [
- "anyhow",
  "async-trait",
  "fastembed",
  "indexmap",
@@ -3024,7 +3013,6 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alcove"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 description = "A quiet place for your project docs. MCP server that gives AI agents scoped access to private documentation."
 license = "Apache-2.0"
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 # Embedding backend — delegates to llm-kernel for model catalog, metadata,
 # and LRU cache. fastembed remains a direct dep for FastEmbedSession
 # (prefix control). llm-kernel uses the same rustls-based defaults.
-llm-kernel = { version = "0.9.2", default-features = false }
+llm-kernel = { version = "0.15", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -40,3 +40,9 @@ libopenblas-dev = "*"
 # runtime path.
 [dist.github-custom-runners]
 aarch64-apple-darwin = "macos-14"
+# Linux builds on ubuntu-24.04 (glibc 2.39): llm-kernel >= 0.12 statically
+# links ort, whose archive references glibc 2.38+ symbols. The 22.04 image
+# (glibc 2.35) fails the release link with `undefined symbol: __isoc23_strtoll`.
+# Trade-off: the produced binaries require glibc >= 2.38 at runtime.
+x86_64-unknown-linux-gnu = "ubuntu-24.04"
+aarch64-unknown-linux-gnu = "ubuntu-24.04"


### PR DESCRIPTION
Re-adopts llm-kernel 0.15.0 (resolved llm-kernel #55). dist Linux on ubuntu-24.04 for glibc 2.38+ static ort link. Adds Release build (Linux/Windows) CI jobs so a static-link regression fails the PR, not the tagged release (the 0.12.3 gap). Bumps alcove to 0.12.5.