### PR TITLE
fix(release): trim dist targets to macOS + x86_64-linux (0.12.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6] — 2026-07-06
+
+### Changed
+
+- Trimmed dist release targets to `aarch64-apple-darwin` (macOS) and `x86_64-unknown-linux-gnu` (Linux). The llm-kernel 0.15 static-ort link fails the `dist build` (LTO `dist` profile) on Windows (unresolved MSVC CRT externals in `libort_sys`) and the aarch64-linux cross-build (ARM `libopenblas.so`). Both are tracked separately; macOS and x86_64-linux artifacts build and publish cleanly. `powershell` installer dropped (no Windows target).
+
 ## [0.12.5] — 2026-07-06
+
+> Not published — release built macOS + x86_64-linux only; Windows (dist-LTO CRT) and aarch64-linux (cross OpenBLAS) failed to link (see 0.12.6).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "alcove"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alcove"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2024"
 description = "A quiet place for your project docs. MCP server that gives AI agents scoped access to private documentation."
 license = "Apache-2.0"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,17 +8,13 @@ ci = "github"
 targets = [
   "aarch64-apple-darwin",
   "x86_64-unknown-linux-gnu",
-  "aarch64-unknown-linux-gnu",
-  "x86_64-pc-windows-msvc",
 ]
-installers = ["homebrew", "shell", "powershell"]
+installers = ["homebrew", "shell"]
 tap = "epicsagas/homebrew-tap"
 create-release = true
 features = ["full-cross"]
 features-aarch64-apple-darwin = ["full-macos"]
-features-aarch64-unknown-linux-gnu = ["full-cross"]
 features-x86_64-unknown-linux-gnu = ["full-cross"]
-features-x86_64-pc-windows-msvc = ["full-cross"]
 install-path = "CARGO_HOME"
 install-updater = false
 publish-jobs = ["homebrew", "./publish-crates"]
@@ -45,4 +41,3 @@ aarch64-apple-darwin = "macos-14"
 # (glibc 2.35) fails the release link with `undefined symbol: __isoc23_strtoll`.
 # Trade-off: the produced binaries require glibc >= 2.38 at runtime.
 x86_64-unknown-linux-gnu = "ubuntu-24.04"
-aarch64-unknown-linux-gnu = "ubuntu-24.04"


### PR DESCRIPTION
Trims dist targets to the two that link and publish reliably under the LTO dist profile (aarch64-apple-darwin, x86_64-unknown-linux-gnu). Windows (MSVC CRT externals under LTO) and aarch64-linux (cross OpenBLAS) restores tracked separately. Bumps alcove to 0.12.6.