### PR TITLE
chore(deps): upgrade llm-kernel 0.15 -> 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded llm-kernel 0.15 → 0.25 (forward-compatible — no source changes; alcove's API surface was unaffected by the 0.16–0.25 breaking changes)
+
+> **Re-index required for BGE-en-v1.5 and mxbai users.** llm-kernel 0.25 extended the BGE-style instruction prefix (`"Represent this sentence for searching relevant passages: "`) from the Arctic models to `BGESmallENV15`, `BGEBaseENV15`, `BGELargeENV15`, and `MxbaiEmbedLargeV1`, which previously had no query prefix. alcove applies prefixes at both index and query time, so indexes built with an earlier llm-kernel using one of those four models now embed queries into a different region of the embedding space than their stored documents, degrading vector search relevance. Run `alcove rebuild` (or `alcove vault rebuild <name>` for a vault) to re-embed. The default model (`MultilingualE5Small`) and all other models are unaffected.
+
 ## [0.12.6] — 2026-07-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,9 +2404,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-kernel"
-version = "0.15.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fb82f7da7e6a1271813248e19eb194e5d186f8fbff157ad63078a71f2c9703"
+checksum = "f92af1170a3daad4d70e6b9186a7bd9d2f3c21e32c0e7083a2e689aa56868ec0"
 dependencies = [
  "async-trait",
  "fastembed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["clock"] }
 # Embedding backend — delegates to llm-kernel for model catalog, metadata,
 # and LRU cache. fastembed remains a direct dep for FastEmbedSession
 # (prefix control). llm-kernel uses the same rustls-based defaults.
-llm-kernel = { version = "0.15", default-features = false }
+llm-kernel = { version = "0.25", default-features = false }
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"], optional = true }
 
 # Storage & indexing

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -548,12 +548,20 @@ mod tests {
                 Some("search_document: ")
             );
 
+            // llm-kernel 0.25 extended this BGE-style instruction prefix from the
+            // Arctic models to BGE-en-v1.5 and mxbai. Indexes built with an older
+            // llm-kernel using those models need re-embedding — queries land in a
+            // different region of the embedding space than the stored documents.
             let arctic_query_prefix = "Represent this sentence for searching relevant passages: ";
             for m in [
                 EmbeddingModel::SnowflakeArcticEmbedXS,
                 EmbeddingModel::SnowflakeArcticEmbedS,
                 EmbeddingModel::SnowflakeArcticEmbedM,
                 EmbeddingModel::SnowflakeArcticEmbedL,
+                EmbeddingModel::BGESmallENV15,
+                EmbeddingModel::BGEBaseENV15,
+                EmbeddingModel::BGELargeENV15,
+                EmbeddingModel::MxbaiEmbedLargeV1,
             ] {
                 assert_eq!(
                     m.query_prefix(),

--- a/src/embedding_cache.rs
+++ b/src/embedding_cache.rs
@@ -9,9 +9,10 @@ use rusqlite::params;
 
 /// Persistent embedding cache backed by SQLite.
 ///
-/// The database file (`embedding_cache.db`) lives alongside `vectors.db` but
-/// is **not** deleted during `force_rebuild`, so cached embeddings survive
-/// across rebuilds.
+/// The database file (`embedding_cache.db`) lives alongside `vectors.db`.
+/// During a `force_rebuild` it is moved aside to `embedding_cache.db.bak`
+/// (regenerated on re-index) so stale embeddings from a model or prefix change
+/// are not reused; a normal incremental index keeps the cache intact.
 pub struct EmbeddingCache {
     conn: rusqlite::Connection,
 }

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -292,6 +292,34 @@ pub fn build_index(docs_root: &Path) -> Result<JsonValue> {
     build_index_with_mode(docs_root, false)
 }
 
+/// Move `embedding_cache.db` (plus its WAL/SHM sidecars) aside to `.bak`
+/// during a force rebuild, so stale embeddings are not reused after a model
+/// or prefix change (e.g. llm-kernel 0.25 query-prefix addition).
+///
+/// Returns the backup path if the cache existed and was moved, `None` if there
+/// was nothing to back up. An existing `.bak` from a prior rebuild is replaced.
+fn backup_embedding_cache(alcove_dir: &Path) -> Result<Option<PathBuf>> {
+    let cache_path = alcove_dir.join("embedding_cache.db");
+    if !cache_path.exists() {
+        return Ok(None);
+    }
+    let backup_path = alcove_dir.join("embedding_cache.db.bak");
+    if backup_path.exists() {
+        std::fs::remove_file(&backup_path)?;
+    }
+    // Move the main DB plus SQLite WAL-mode sidecars so the backup is complete.
+    for suffix in ["", "-wal", "-shm"] {
+        let src = alcove_dir.join(format!("embedding_cache.db{suffix}"));
+        if src.exists() {
+            std::fs::rename(
+                &src,
+                alcove_dir.join(format!("embedding_cache.db{suffix}.bak")),
+            )?;
+        }
+    }
+    Ok(Some(backup_path))
+}
+
 pub fn rebuild_index(docs_root: &Path) -> Result<JsonValue> {
     // Evict the cached reader before wiping the index directory so that any
     // search initiated after this call opens a fresh reader on the new data.
@@ -328,6 +356,9 @@ fn build_index_with_options(
         if vectors_path.exists() {
             std::fs::remove_file(&vectors_path)?;
         }
+        // Back up the embedding cache so stale embeddings (e.g. from a prefix
+        // change) are not reused; it is regenerated during re-indexing.
+        backup_embedding_cache(&docs_root.join(".alcove"))?;
     }
     let result = build_index_inner(docs_root, skip_embedding);
     release_lock(docs_root);
@@ -1371,6 +1402,8 @@ pub fn rebuild_vault_index(vault_path: &Path) -> Result<JsonValue> {
     if vectors_path.exists() {
         std::fs::remove_file(&vectors_path)?;
     }
+    // Back up the embedding cache so stale embeddings are not reused.
+    backup_embedding_cache(&vault_path.join(".alcove"))?;
 
     build_vault_index(vault_path)
 }


### PR DESCRIPTION
Forward-compatible upgrade — no source changes required. alcove's API surface (`EmbeddingModel`, `EmbeddingCache`, `TurbovecIndex`, `cosine_similarity`, `is_model_cached`) was unaffected by the 0.16–0.25 breaking changes (0.13 `anyhow` → `crate::error::Result`, 0.14 `non_exhaustive`, 0.15 fastembed feature mutual exclusion).

**Runtime behavior change — not caught by the compiler.** 0.25 extended the BGE-style instruction query prefix (`"Represent this sentence for searching relevant passages: "`) from the Arctic models to `BGESmallENV15`, `BGEBaseENV15`, `BGELargeENV15`, and `MxbaiEmbedLargeV1`, which previously returned `None`. alcove applies prefixes at both index time (`index/builder.rs`) and query time (`index/searcher.rs`), so indexes built with an earlier llm-kernel using one of those four models now embed queries into a different region of the embedding space than their stored documents, degrading vector search relevance. Those users need `alcove rebuild`. The default model (`MultilingualE5Small`) and all other models are unaffected — verified by probing actual prefix values on both versions.

`test_model_prefixes` now pins the new prefix behavior for all four models so a future silent change fails the PR.

## Verification

- `cargo build` (default features) — pass
- `cargo build --features embed,turboquant` — pass
- `cargo test --features embed,turboquant` — 518 passed, 0 failed
- `cargo clippy --features embed,turboquant` — 0 warnings

Note: the last two llm-kernel upgrades (0.14, 0.15) were rolled back or patched over release-link failures on Windows / aarch64-linux. Worth confirming the `Release build (Linux/Windows)` CI jobs are green before merge.